### PR TITLE
TH-18: Order now button doesn't work correctly in new themes

### DIFF
--- a/themes/aura/assets/add-to-cart.js
+++ b/themes/aura/assets/add-to-cart.js
@@ -35,7 +35,7 @@ async function addToCart(snippetId) {
 
     stopLoad('#loading__cart');
 
-    const checkoutPageUrl = response.one_page_checkout === true ? response.all_in_one_url : response.checkout_info_url;
+    const checkoutPageUrl = response.one_page_checkout === true ? response.all_in_one_checkout_url : response.checkout_info_url;
 
     if (IS_CART_SKIPED){
       window.location.href = checkoutPageUrl;

--- a/themes/aura/assets/add-to-cart.js
+++ b/themes/aura/assets/add-to-cart.js
@@ -35,8 +35,10 @@ async function addToCart(snippetId) {
 
     stopLoad('#loading__cart');
 
+    const checkoutPageUrl = response.one_page_checkout === true ? response.all_in_one_url : response.checkout_info_url;
+
     if (IS_CART_SKIPED){
-      window.location.href = CHECKOUT_PAGE_URL;
+      window.location.href = checkoutPageUrl;
 
       return;
     }

--- a/themes/aura/snippets/add-to-cart.liquid
+++ b/themes/aura/snippets/add-to-cart.liquid
@@ -32,5 +32,4 @@
   }
 
   const IS_CART_SKIPED = "{{ skip_cart }}";
-  const CHECKOUT_PAGE_URL = "{{ checkout_page_url }}";
 {% endjavascript %}

--- a/themes/aura/snippets/single-product-placeholder.liquid
+++ b/themes/aura/snippets/single-product-placeholder.liquid
@@ -39,7 +39,7 @@
           {%- when 'product_description' -%}
           <p class='product-description'>This is a placeholder description for the product.</p>
           {%- when 'add_to_cart' -%}
-            {% render 'add-to-cart', text: block.settings.text_content, is_sticky: block.settings.is_sticky, background_color: block.settings.background_color, text_color: block.settings.text_color, snippetId: snippetId, skip_cart: block.settings.skip_cart, checkout_page_url: cart.cart_submit_url, is_placeholder: is_placeholder %}
+            {% render 'add-to-cart', text: block.settings.text_content, is_sticky: block.settings.is_sticky, background_color: block.settings.background_color, text_color: block.settings.text_color, snippetId: snippetId, skip_cart: block.settings.skip_cart, is_placeholder: is_placeholder %}
             {%- when 'accordion' -%}
               {%- render 'accordion', accordion_title: block.settings.accordion_title, accordion_details: block.settings.accordion_details, background_color: block.settings.background_color, text_color: block.settings.text_color, space_bottom: block.settings.space_bottom -%}
           {%- when 'express_checkout' -%}

--- a/themes/aura/snippets/single-product.liquid
+++ b/themes/aura/snippets/single-product.liquid
@@ -74,7 +74,7 @@
           {%- when 'stock' -%}
             {% render 'stock', stock_title: block.settings.stock_title, stock_items_left: block.settings.stock_items_left, total_stock_items: block.settings.total_stock_items %}
           {%- when 'add_to_cart' -%}
-            {% render 'add-to-cart', text: block.settings.text_content, is_sticky: block.settings.is_sticky, background_color: block.settings.background_color, text_color: block.settings.text_color, snippetId: snippetId, skip_cart: block.settings.skip_cart, checkout_page_url: cart.cart_submit_url %}
+            {% render 'add-to-cart', text: block.settings.text_content, is_sticky: block.settings.is_sticky, background_color: block.settings.background_color, text_color: block.settings.text_color, snippetId: snippetId, skip_cart: block.settings.skip_cart %}
           {%- when 'accordion' -%}
               {%- render 'accordion', accordion_title: block.settings.accordion_title, accordion_details: block.settings.accordion_details, background_color: block.settings.background_color, text_color: block.settings.text_color, space_bottom: block.settings.space_bottom -%}
           {%- when 'express_checkout' -%}

--- a/themes/harmony/assets/add-to-cart.js
+++ b/themes/harmony/assets/add-to-cart.js
@@ -35,7 +35,7 @@ async function addToCart(snippetId) {
 
     stopLoad('#loading__cart');
 
-    const checkoutPageUrl = response.one_page_checkout === true ? response.all_in_one_url : response.checkout_info_url;
+    const checkoutPageUrl = response.one_page_checkout === true ? response.all_in_one_checkout_url : response.checkout_info_url;
 
     if (IS_CART_SKIPED){
       window.location.href = checkoutPageUrl;

--- a/themes/harmony/assets/add-to-cart.js
+++ b/themes/harmony/assets/add-to-cart.js
@@ -35,8 +35,10 @@ async function addToCart(snippetId) {
 
     stopLoad('#loading__cart');
 
+    const checkoutPageUrl = response.one_page_checkout === true ? response.all_in_one_url : response.checkout_info_url;
+
     if (IS_CART_SKIPED){
-      window.location.href = CHECKOUT_PAGE_URL;
+      window.location.href = checkoutPageUrl;
 
       return;
     }

--- a/themes/harmony/snippets/add-to-cart.liquid
+++ b/themes/harmony/snippets/add-to-cart.liquid
@@ -42,5 +42,4 @@
   }
 
   const IS_CART_SKIPED = "{{ block_settings.skip_cart }}";
-  const CHECKOUT_PAGE_URL = "{{ checkout_page_url }}";
 {% endjavascript %}

--- a/themes/harmony/snippets/single-product-placeholder.liquid
+++ b/themes/harmony/snippets/single-product-placeholder.liquid
@@ -39,7 +39,7 @@
           {%- when 'product_description' -%}
           <p class='product-description'>This is a placeholder description for the product.</p>
           {%- when 'add_to_cart' -%}
-            {% render 'add-to-cart', block_settings: block.settings, snippetId: snippetId, checkout_page_url: cart.cart_submit_url, is_placeholder: is_placeholder %}
+            {% render 'add-to-cart', block_settings: block.settings, snippetId: snippetId, is_placeholder: is_placeholder %}
             {%- when 'accordion' -%}
               {%- render 'accordion', accordion_title: block.settings.accordion_title, accordion_details: block.settings.accordion_details, background_color: block.settings.background_color, text_color: block.settings.text_color, space_bottom: block.settings.space_bottom -%}
           {%- when 'express_checkout' -%}

--- a/themes/harmony/snippets/single-product.liquid
+++ b/themes/harmony/snippets/single-product.liquid
@@ -74,7 +74,7 @@
           {%- when 'stock' -%}
             {% render 'stock', stock_title: block.settings.stock_title, stock_items_left: block.settings.stock_items_left, total_stock_items: block.settings.total_stock_items %}
           {%- when 'add_to_cart' -%}
-            {% render 'add-to-cart', block_settings: block.settings, snippetId: snippetId, checkout_page_url: cart.cart_submit_url %}
+            {% render 'add-to-cart', block_settings: block.settings, snippetId: snippetId %}
           {%- when 'accordion' -%}
               {%- render 'accordion', accordion_title: block.settings.accordion_title, accordion_details: block.settings.accordion_details, background_color: block.settings.background_color, text_color: block.settings.text_color, space_bottom: block.settings.space_bottom -%}
           {%- when 'express_checkout' -%}

--- a/themes/meraki/assets/add-to-cart.js
+++ b/themes/meraki/assets/add-to-cart.js
@@ -35,7 +35,7 @@ async function addToCart(snippetId) {
 
     stopLoad('#loading__cart');
 
-    const checkoutPageUrl = response.one_page_checkout === true ? response.all_in_one_url : response.checkout_info_url;
+    const checkoutPageUrl = response.one_page_checkout === true ? response.all_in_one_checkout_url : response.checkout_info_url;
 
     if (IS_CART_SKIPED){
       window.location.href = checkoutPageUrl;

--- a/themes/meraki/assets/add-to-cart.js
+++ b/themes/meraki/assets/add-to-cart.js
@@ -35,8 +35,10 @@ async function addToCart(snippetId) {
 
     stopLoad('#loading__cart');
 
+    const checkoutPageUrl = response.one_page_checkout === true ? response.all_in_one_url : response.checkout_info_url;
+
     if (IS_CART_SKIPED){
-      window.location.href = CHECKOUT_PAGE_URL;
+      window.location.href = checkoutPageUrl;
 
       return;
     }

--- a/themes/meraki/snippets/add-to-cart.liquid
+++ b/themes/meraki/snippets/add-to-cart.liquid
@@ -43,5 +43,4 @@
   }
 
   const IS_CART_SKIPED = "{{ skip_cart }}";
-  const CHECKOUT_PAGE_URL = "{{ checkout_page_url }}";
 {% endjavascript %}

--- a/themes/meraki/snippets/single-product.liquid
+++ b/themes/meraki/snippets/single-product.liquid
@@ -66,7 +66,7 @@
           {%- when 'stock' -%}
             {% render 'stock', stock_title: block.settings.stock_title, stock_items_left: block.settings.stock_items_left, total_stock_items: block.settings.total_stock_items %}
           {%- when 'add_to_cart' -%}
-            {% render 'add-to-cart', text: block.settings.text_content, is_sticky: block.settings.is_sticky, background_color: block.settings.background_color, text_color: block.settings.text_color, snippetId: snippetId, skip_cart: block.settings.skip_cart, checkout_page_url: cart.cart_submit_url %}
+            {% render 'add-to-cart', text: block.settings.text_content, is_sticky: block.settings.is_sticky, background_color: block.settings.background_color, text_color: block.settings.text_color, snippetId: snippetId, skip_cart: block.settings.skip_cart %}
           {%- when 'accordion' -%}
               {%- render 'accordion', accordion_title: block.settings.accordion_title, accordion_details: block.settings.accordion_details, border_color: block.settings.border_color, text_color: block.settings.text_color, space_bottom: block.settings.space_bottom -%}
           {%- when 'express_checkout' -%}


### PR DESCRIPTION
Ticket: [TH-18](https://youcanshop.atlassian.net/browse/TH-18)

## QA
 - Check this branch locally and run `pnpm run release`
 - 3 new files will be generated in this format `theme name + date + .zip`
 - Go to [test environment](https://seller-area.testyoucan.shop/admin/themes) seller-area
 - Upload each .zip file and activate them and test each one with the following process: 
     - In theme editor go to product page > single page section > add to cart block
     - Activate skip cart feature
     - Now in your storefront theme go to the product page and click on add to cart button
     - Check if the page doesn't reload and it takes you to the checkout information page

### Note

Please read ticket description for more details

[TH-18]: https://youcanshop.atlassian.net/browse/TH-18?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ