### PR TITLE
TH-68: Preload google font

### DIFF
--- a/themes/aura/snippets/head-config.liquid
+++ b/themes/aura/snippets/head-config.liquid
@@ -8,15 +8,8 @@
   content='width=device-width, initial-scale=1.0'
 >
 
-<link
-  rel='preload'
-  href='https://fonts.googleapis.com/css2?family={{ section.settings.navbar_font_family }}:ital,wght@0,300;0,400;0,500;0,700;1,400&display=swap'
-  as='style'
->
-<link
-  rel='stylesheet'
-  href='https://fonts.googleapis.com/css2?family={{ section.settings.navbar_font_family }}:ital,wght@0,300;0,400;0,500;0,700;1,400&display=swap'
->
+<link rel="preload" href="https://fonts.googleapis.com/css2?family={{ settings.font_family }}:ital,wght@0,300;0,400;0,500;0,700;1,400&display=swap" as="style">
+<link rel="stylesheet" href="https://fonts.googleapis.com/css2?family={{ settings.font_family }}:ital,wght@0,300;0,400;0,500;0,700;1,400&display=swap">
 
 {%- style -%}
   :root {

--- a/themes/aura/snippets/head-config.liquid
+++ b/themes/aura/snippets/head-config.liquid
@@ -9,8 +9,13 @@
 >
 
 <link
-  href='https://fonts.googleapis.com/css2?family={{ settings.font_family }}:ital,wght@0,300;0,400;0,500;0,700;1,400&display=swap'
+  rel='preload'
+  href='https://fonts.googleapis.com/css2?family={{ section.settings.navbar_font_family }}:ital,wght@0,300;0,400;0,500;0,700;1,400&display=swap'
+  as='style'
+>
+<link
   rel='stylesheet'
+  href='https://fonts.googleapis.com/css2?family={{ section.settings.navbar_font_family }}:ital,wght@0,300;0,400;0,500;0,700;1,400&display=swap'
 >
 
 {%- style -%}

--- a/themes/aura/snippets/head-config.liquid
+++ b/themes/aura/snippets/head-config.liquid
@@ -8,7 +8,8 @@
   content='width=device-width, initial-scale=1.0'
 >
 
-<link rel="preload" href="https://fonts.googleapis.com/css2?family={{ settings.font_family }}:ital,wght@0,300;0,400;0,500;0,700;1,400&display=swap" as="style">
+<link rel="preconnect" href="https://fonts.googleapis.com">
+<link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
 <link rel="stylesheet" href="https://fonts.googleapis.com/css2?family={{ settings.font_family }}:ital,wght@0,300;0,400;0,500;0,700;1,400&display=swap">
 
 {%- style -%}

--- a/themes/harmony/assets/reviews.css
+++ b/themes/harmony/assets/reviews.css
@@ -1,3 +1,4 @@
+@charset "UTF-8";
 .yc-product-reviews {
   margin-bottom: 80px;
   max-width: 904px;

--- a/themes/harmony/snippets/head-config.liquid
+++ b/themes/harmony/snippets/head-config.liquid
@@ -7,11 +7,8 @@
   name='viewport'
   content='width=device-width, initial-scale=1.0'
 >
-
-<link
-  href='https://fonts.googleapis.com/css2?family={{ settings.font_family }}:ital,wght@0,300;0,400;0,500;0,700;1,400&display=swap'
-  rel='stylesheet'
->
+<link rel="preload" href="https://fonts.googleapis.com/css2?family={{ settings.font_family }}:ital,wght@0,300;0,400;0,500;0,700;1,400&display=swap" as="style">
+<link rel="stylesheet" href="https://fonts.googleapis.com/css2?family={{ settings.font_family }}:ital,wght@0,300;0,400;0,500;0,700;1,400&display=swap">
 
 {%- style -%}
   :root {

--- a/themes/harmony/snippets/head-config.liquid
+++ b/themes/harmony/snippets/head-config.liquid
@@ -7,7 +7,9 @@
   name='viewport'
   content='width=device-width, initial-scale=1.0'
 >
-<link rel="preload" href="https://fonts.googleapis.com/css2?family={{ settings.font_family }}:ital,wght@0,300;0,400;0,500;0,700;1,400&display=swap" as="style">
+
+<link rel="preconnect" href="https://fonts.googleapis.com">
+<link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
 <link rel="stylesheet" href="https://fonts.googleapis.com/css2?family={{ settings.font_family }}:ital,wght@0,300;0,400;0,500;0,700;1,400&display=swap">
 
 {%- style -%}

--- a/themes/meraki/assets/reviews.css
+++ b/themes/meraki/assets/reviews.css
@@ -1,4 +1,3 @@
-@charset "UTF-8";
 .yc-product-reviews {
   background-color: #FBFBFB;
   padding: 36px 0;

--- a/themes/meraki/snippets/head-config.liquid
+++ b/themes/meraki/snippets/head-config.liquid
@@ -8,10 +8,8 @@
   content='width=device-width, initial-scale=1.0'
 >
 
-<link
-  href='https://fonts.googleapis.com/css2?family={{ settings.font_family }}:ital,wght@0,300;0,400;0,500;0,700;1,400&display=swap'
-  rel='stylesheet'
->
+<link rel="preload" href="https://fonts.googleapis.com/css2?family={{ settings.font_family }}:ital,wght@0,300;0,400;0,500;0,700;1,400&display=swap" as="style">
+<link rel="stylesheet" href="https://fonts.googleapis.com/css2?family={{ settings.font_family }}:ital,wght@0,300;0,400;0,500;0,700;1,400&display=swap">
 
 {%- style -%}
   :root {

--- a/themes/meraki/snippets/head-config.liquid
+++ b/themes/meraki/snippets/head-config.liquid
@@ -8,7 +8,8 @@
   content='width=device-width, initial-scale=1.0'
 >
 
-<link rel="preload" href="https://fonts.googleapis.com/css2?family={{ settings.font_family }}:ital,wght@0,300;0,400;0,500;0,700;1,400&display=swap" as="style">
+<link rel="preconnect" href="https://fonts.googleapis.com">
+<link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
 <link rel="stylesheet" href="https://fonts.googleapis.com/css2?family={{ settings.font_family }}:ital,wght@0,300;0,400;0,500;0,700;1,400&display=swap">
 
 {%- style -%}


### PR DESCRIPTION
> [!Note]
> This change doesn't have any significant performance improvement but it is recommended to preconnect resources like fonts to reduce the initial latency involved in DNS lookups

## JIRA Ticket

Ticket: [TH-68](https://youcanshop.atlassian.net/browse/TH-68).

## Prerequisites

* [ ] Check this branch locally and run `pnpm run release`
* [ ] 3 new files will be generated in this format `theme name + date + .zip`
* [ ] Upload generated file locally or in seller-area test env

## QA Steps

* [ ] See code


[TH-68]: https://youcanshop.atlassian.net/browse/TH-68?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ