### PR TITLE
TH-70: Theme editor > No way of clearing navbar's font-family

### DIFF
--- a/themes/aura/sections/main-navbar.liquid
+++ b/themes/aura/sections/main-navbar.liquid
@@ -310,6 +310,10 @@
       "label": "Font family",
       "options": [
         {
+          "value": "",
+          "label": "Default"
+        },
+        {
           "value": "Roboto",
           "label": "Roboto"
         },
@@ -333,7 +337,8 @@
           "value": "Montserrat",
           "label": "Montserrat"
         }
-      ]
+      ],
+      "default": ""
     },
     {
       "type": "checkbox",

--- a/themes/harmony/sections/main-navbar.liquid
+++ b/themes/harmony/sections/main-navbar.liquid
@@ -324,6 +324,10 @@
       "label": "Font family",
       "options": [
         {
+          "value": "",
+          "label": "Default"
+        },
+        {
           "value": "Roboto",
           "label": "Roboto"
         },
@@ -347,7 +351,8 @@
           "value": "Montserrat",
           "label": "Montserrat"
         }
-      ]
+      ],
+      "default": ""
     },
     {
       "type": "checkbox",

--- a/themes/meraki/sections/main-navbar.liquid
+++ b/themes/meraki/sections/main-navbar.liquid
@@ -275,6 +275,10 @@
       "label": "Font family",
       "options": [
         {
+          "value": "",
+          "label": "Default"
+        },
+        {
           "value": "Roboto",
           "label": "Roboto"
         },
@@ -306,7 +310,8 @@
           "value": "Almarai",
           "label": "Almarai"
         }
-      ]
+      ],
+      "default": ""
     },
     {
       "type": "checkbox",


### PR DESCRIPTION
## JIRA Ticket

Ticket: [TH_70](https://youcanshop.atlassian.net/browse/TH_70).

## Prerequisites

* [ ] Check this branch locally and run `pnpm run release`
* [ ] 3 new files will be generated in this format `theme name + date + .zip`
* [ ] Upload generated file locally or in seller-area test env

## QA Steps

* [ ] Go to https://seller-area.youcan.shop/admin/themes
* [ ] Try to active `Aura` or `Meraki` or `Harmony` theme -> Customize
* [ ] `Navbar` section -> Verify that the `font-family` dropdown has the "default" option.
 
> [!IMPORTANT]
> If you're installing for the first time, when you check the `navbar` font family, it should have a `default` option selected automatically (the font family of your theme should be the default), instead of being `empty`. In the future, if you update the font family of the navbar and want to `revert` to the original setting, you can simply select the default option to set it back to the `original` font family.

## Preview

<img width="284" alt="Screenshot 2024-08-28 at 12 13 18" src="https://github.com/user-attachments/assets/2c05fbed-e5ab-47d9-9e49-6c8d0594e649">

## Note

Leave empty when you have nothing to say.
