### PR TITLE
Dark: Restores the JS code that fetches product reviews

### DIFF
--- a/themes/aura/sections/product.liquid
+++ b/themes/aura/sections/product.liquid
@@ -464,6 +464,12 @@
 
     const sectionProductId = '{{ selected_product.id }}';
     const sizeBigMessage = "{{ 'general.size_big_message' | t }}";
+
+    document.addEventListener('DOMContentLoaded', () => {
+      const parentContainer = '.yc-single-product';
+
+      fetchReviewsForProduct(sectionProductId, parentContainer, {{ selected_product.averageRating }});
+    });
   {% endif %}
 {%- endjavascript -%}
 

--- a/themes/harmony/sections/product.liquid
+++ b/themes/harmony/sections/product.liquid
@@ -463,6 +463,12 @@
 
     const sectionProductId = '{{ selected_product.id }}';
     const sizeBigMessage = "{{ 'general.size_big_message' | t }}";
+
+    document.addEventListener('DOMContentLoaded', () => {
+      const parentContainer = '.yc-single-product';
+
+      fetchReviewsForProduct(sectionProductId, parentContainer, {{ selected_product.averageRating }});
+    });
   {% endif %}
 {%- endjavascript -%}
 

--- a/themes/meraki/sections/product.liquid
+++ b/themes/meraki/sections/product.liquid
@@ -441,6 +441,12 @@
 
     const sectionProductId = '{{ selected_product.id }}';
     const sizeBigMessage = "{{ 'general.size_big_message' | t }}";
+
+    document.addEventListener('DOMContentLoaded', () => {
+      const parentContainer = '.yc-single-product';
+
+      fetchReviewsForProduct(sectionProductId, parentContainer, {{ selected_product.averageRating }});
+    });
   {% endif %}
 {%- endjavascript -%}
 


### PR DESCRIPTION
## JIRA Ticket

Ticket: [TH_X](https://youcanshop.atlassian.net/browse/TH_X).

## Prerequisites

* [ ] Check this branch locally and run `pnpm run release`
* [ ] 3 new files will be generated in this format `theme name + date + .zip`
* [ ] Upload generated file locally or in seller-area test env

## QA Steps

* [ ] Go to https://seller-area.youcan.shop/admin/themes
* [ ] Try to active a new theme (`Aura`, `Meraki`, or `Harmony`)
* [ ] Go to `Theme Editor` > `Products` > `Single product` section > `Review`.
* [ ] You will see the `Review` section appear again.


> [!IMPORTANT]
> This PR `restores` some JS code that was accidentally removed. The missing code was `fetching` review data, which caused the product `review` section to disappear. By adding the code back, the section will reappear in the **theme editor** / **stores**. This issue is related to this [ticket](https://github.com/youcan-shop/youcan-themes/pull/18).

```js
document.addEventListener('DOMContentLoaded', () => {
  const parentContainer = '.yc-single-product';

  fetchReviewsForProduct(sectionProductId, parentContainer, {{ selected_product.averageRating }});
});
```


## Note

Leave empty when you have nothing to say.
