### PR TITLE
TH-176-harmony: Fix logo squished in mobile cart

### DIFF
--- a/themes/harmony/assets/navbar.css
+++ b/themes/harmony/assets/navbar.css
@@ -235,6 +235,9 @@
 }
 .navigation-drawer .logo img{
   max-height:40px;
+  max-width:100%;
+  width:-moz-fit-content;
+  width:fit-content;
 }
 .navigation-drawer .items{
   padding:20px 16px;

--- a/themes/harmony/assets/navbar.css
+++ b/themes/harmony/assets/navbar.css
@@ -233,7 +233,12 @@
   padding:20px 16px;
   display:block;
 }
-.navigation-drawer .logo img{
+.navigation-drawer .logo a{
+  display:inline-block;
+  width:-moz-fit-content;
+  width:fit-content;
+}
+.navigation-drawer .logo a img{
   max-height:40px;
   max-width:100%;
   width:-moz-fit-content;

--- a/themes/harmony/assets/navbar.css
+++ b/themes/harmony/assets/navbar.css
@@ -258,7 +258,8 @@
   border-color:rgba(0, 0, 0, 0.1);
 }
 .navigation-drawer .close-drawer-btn{
-  float:left;
+  position:absolute;
+  left:0;
   cursor:pointer;
   width:40px;
   height:40px;

--- a/themes/harmony/styles/navbar.scss
+++ b/themes/harmony/styles/navbar.scss
@@ -305,7 +305,8 @@
   }
 
   .close-drawer-btn {
-    float: left;
+    position: absolute;
+    inset-inline-start: 0;
     cursor: pointer;
     width: 40px;
     height: 40px;

--- a/themes/harmony/styles/navbar.scss
+++ b/themes/harmony/styles/navbar.scss
@@ -277,6 +277,8 @@
 
     img {
       max-height: 40px;
+      max-width: 100%;
+      width: fit-content;
     }
   }
 

--- a/themes/harmony/styles/navbar.scss
+++ b/themes/harmony/styles/navbar.scss
@@ -275,10 +275,15 @@
     padding: 20px 16px;
     display: block;
 
-    img {
-      max-height: 40px;
-      max-width: 100%;
+    a {
+      display: inline-block;
       width: fit-content;
+
+      img {
+        max-height: 40px;
+        max-width: 100%;
+        width: fit-content;
+      }
     }
   }
 


### PR DESCRIPTION
## JIRA Ticket

Ticket: [TH-176](https://youcanshop.atlassian.net/browse/TH-176).

## QA Steps
* [ ] Go to /admin/themes
* [ ] Activate Harmony
* [ ] Go to theme editor
* [ ] Switch to mobile view
* [ ] Click on the burger menu icon
* [ ] From the properties panel, upload a logo, any image will do
* [ ] After the image is uploaded hit save
* [ ] Open the sidemenu
* [ ] The should be well proportioned and not squished 

## Note

Leave empty when you have nothing to say.


[TH-176]: https://youcanshop.atlassian.net/browse/TH-176?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ