### PR TITLE
TH-176-aura: Fix logo squished in mobile sidemenu

### DIFF
--- a/themes/aura/assets/navbar.css
+++ b/themes/aura/assets/navbar.css
@@ -192,6 +192,9 @@
 }
 .navigation-drawer .logo img{
   max-height:40px;
+  max-width:100%;
+  width:-moz-fit-content;
+  width:fit-content;
 }
 .navigation-drawer .items{
   padding:20px 16px;

--- a/themes/aura/assets/navbar.css
+++ b/themes/aura/assets/navbar.css
@@ -215,7 +215,7 @@
   border-color:rgba(0, 0, 0, 0.1);
 }
 .navigation-drawer .close-drawer-btn{
-  float:left;
+  position:absolute;
   cursor:pointer;
   width:40px;
   height:40px;

--- a/themes/aura/assets/navbar.css
+++ b/themes/aura/assets/navbar.css
@@ -216,6 +216,7 @@
 }
 .navigation-drawer .close-drawer-btn{
   position:absolute;
+  left:0;
   cursor:pointer;
   width:40px;
   height:40px;

--- a/themes/aura/assets/navbar.css
+++ b/themes/aura/assets/navbar.css
@@ -190,7 +190,12 @@
   padding:20px 16px;
   display:block;
 }
-.navigation-drawer .logo img{
+.navigation-drawer .logo a{
+  display:inline-block;
+  width:-moz-fit-content;
+  width:fit-content;
+}
+.navigation-drawer .logo a img{
   max-height:40px;
   max-width:100%;
   width:-moz-fit-content;

--- a/themes/aura/styles/navbar.scss
+++ b/themes/aura/styles/navbar.scss
@@ -253,7 +253,7 @@
   }
 
   .close-drawer-btn {
-    float: left;
+    position: absolute;
     cursor: pointer;
     width: 40px;
     height: 40px;

--- a/themes/aura/styles/navbar.scss
+++ b/themes/aura/styles/navbar.scss
@@ -223,10 +223,15 @@
     padding: 20px 16px;
     display: block;
 
-    img {
-      max-height: 40px;
-      max-width: 100%;
+    a {
+      display: inline-block;
       width: fit-content;
+
+      img {
+        max-height: 40px;
+        max-width: 100%;
+        width: fit-content;
+      }
     }
   }
 

--- a/themes/aura/styles/navbar.scss
+++ b/themes/aura/styles/navbar.scss
@@ -254,6 +254,7 @@
 
   .close-drawer-btn {
     position: absolute;
+    inset-inline-start: 0;
     cursor: pointer;
     width: 40px;
     height: 40px;

--- a/themes/aura/styles/navbar.scss
+++ b/themes/aura/styles/navbar.scss
@@ -225,6 +225,8 @@
 
     img {
       max-height: 40px;
+      max-width: 100%;
+      width: fit-content;
     }
   }
 


### PR DESCRIPTION
## JIRA Ticket

Ticket: [TH-176](https://youcanshop.atlassian.net/browse/TH-176).

## QA Steps
* [ ] Go to /admin/themes
* [ ] Activate Aura
* [ ] Go to theme editor
* [ ] Switch to mobile view
* [ ] Click on the burger menu icon
* [ ] From the properties panel, upload a logo, any image will do
* [ ] After the image is uploaded hit save
* [ ] Open the sidemenu
* [ ] The should be well proportioned and not squished 

## Note

Leave empty when you have nothing to say.


[TH-176]: https://youcanshop.atlassian.net/browse/TH-176?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ