### PR TITLE
TH-109: Harmony > Prevent the customer from placing an order if a variant is out of stock

### DIFF
--- a/themes/aura/assets/dropdown-menu.js
+++ b/themes/aura/assets/dropdown-menu.js
@@ -1,5 +1,4 @@
 let isDropDownOpened = false;
-
 /**
  * @param {HTMLElement} element
  */

--- a/themes/aura/assets/dropdown-menu.js
+++ b/themes/aura/assets/dropdown-menu.js
@@ -1,4 +1,5 @@
 let isDropDownOpened = false;
+
 /**
  * @param {HTMLElement} element
  */

--- a/themes/harmony/assets/add-to-cart.js
+++ b/themes/harmony/assets/add-to-cart.js
@@ -194,9 +194,9 @@ function cartTemplate(item) {
           <div class="spinner" data-spinner-id="${item.id}" style="display: none;"></div>
           <!--
             <div class="quantity-control">
-              <button class="increase-btn cart-quantity-btn" onclick="increaseCartQuantity('${item.id}', '${item.productVariant.id}', , '${variantInventory}')">+</button>
+              <button class="increase-btn cart-quantity-btn" onclick="increaseCartQuantity('${item.id}', '${item.productVariant.id}', '${variantInventory}')">+</button>
               <input type="number" id="quantity-${item.id}" value="${item.quantity}" min="1" onchange="updateCartItem('${item.id}', '${item.productVariant.id}', this.value)" oninput="restrictInputValue(event.target, ${variantInventory})">
-              <button class="decrease-btn cart-quantity-btn" onclick="decreaseCartQuantity('${item.id}', '${item.productVariant.id}', , '${variantInventory}')">-</button>
+              <button class="decrease-btn cart-quantity-btn" onclick="decreaseCartQuantity('${item.id}', '${item.productVariant.id}', '${variantInventory}')">-</button>
             </div>
           -->
         </div>

--- a/themes/harmony/assets/add-to-cart.js
+++ b/themes/harmony/assets/add-to-cart.js
@@ -64,9 +64,11 @@ function attachRemoveItemListeners() {
       const cartItemId = event.target.getAttribute('data-cart-item-id');
       const productVariantId = event.target.getAttribute('data-product-variant-id');
 
-      await removeCartItem(cartItemId, productVariantId);
-      await updateCartDrawer();
-      updateCartCount(-1, true);
+      if(cartItemId && productVariantId) {
+        await removeCartItem(cartItemId, productVariantId);
+        await updateCartDrawer();
+        updateCartCount(-1, true);
+      }
     })
   );
 }
@@ -303,7 +305,7 @@ function showSpinner(spinnerElement) {
 }
 
 function hideSpinner(spinnerElement) {
-  const spinnerAction = spinnerElement.previousElementSibling;
+  const spinnerAction = spinnerElement?.previousElementSibling;
   toggleVisibility(spinnerElement, spinnerAction);
 }
 
@@ -368,15 +370,15 @@ function preventCartDrawerOpening(templateName) {
   window.location.reload();
 }
 
-async function directAddToCart(event, productId, inventory) {
+async function directAddToCart(event, productId, inventory, isTrackingInventory) {
   event.preventDefault();
 
   await trackVariantQuantityOnCart(productId);
-
   const variantQuantityInCart = parseInt(document.querySelector('#cartQuantity')?.value) || null;
+  const isTrackingInventoryAvailable = Boolean(isTrackingInventory) &&  Number.isFinite(inventory);
   const newQuantity = 1;
 
-  if (Number.isFinite(inventory) && ((variantQuantityInCart ?? 0) + newQuantity) > inventory) {
+  if (isTrackingInventoryAvailable && ((variantQuantityInCart ?? 0) + newQuantity) > inventory) {
     return notify(ADD_TO_CART_EXPECTED_ERRORS.max_quantity + inventory, 'warning');
   }
 

--- a/themes/harmony/assets/add-to-cart.js
+++ b/themes/harmony/assets/add-to-cart.js
@@ -305,7 +305,7 @@ function showSpinner(spinnerElement) {
 }
 
 function hideSpinner(spinnerElement) {
-  const spinnerAction = spinnerElement?.previousElementSibling;
+  const spinnerAction = spinnerElement.previousElementSibling;
   toggleVisibility(spinnerElement, spinnerAction);
 }
 

--- a/themes/harmony/assets/add-to-cart.js
+++ b/themes/harmony/assets/add-to-cart.js
@@ -1,9 +1,10 @@
 async function addToCart(snippetId) {
   const parentSection = document.querySelector(`#s-${snippetId}`);
   const variantId = parentSection.querySelector(`#variantId`)?.value || undefined;
-  const quantity = parentSection.querySelector(`#quantity`)?.value || 1;
-  const inventory = parentSection.querySelector(`#_inventory`)?.value || null;
+  const quantity = parseInt(parentSection.querySelector(`#quantity`)?.value) || 1;
+  const inventory = parseInt(parentSection.querySelector(`#_inventory`)?.value) || null;
   const uploadedImageLink = parentSection.querySelector(`#yc-upload-link`)?.value || undefined;
+  const variantQuantityInCart = parseInt(document.querySelector('#cartQuantity')?.value) || null;
 
   if (!variantId) {
     return notify(ADD_TO_CART_EXPECTED_ERRORS.select_variant, 'error');
@@ -13,8 +14,12 @@ async function addToCart(snippetId) {
     return notify(ADD_TO_CART_EXPECTED_ERRORS.quantity_smaller_than_zero, 'error');
   }
 
-  if (inventory == 0) {
+  if (inventory === 0) {
     return notify(ADD_TO_CART_EXPECTED_ERRORS.empty_inventory, 'error');
+  }
+
+  if (Number.isFinite(inventory) && ((variantQuantityInCart ?? 0) + quantity) > inventory) {
+    return notify(ADD_TO_CART_EXPECTED_ERRORS.max_quantity + inventory, 'warning');
   }
 
   try {
@@ -27,6 +32,8 @@ async function addToCart(snippetId) {
       attachedImage: uploadedImageLink,
       quantity,
     });
+
+    await trackVariantQuantityOnCart(variantId);
 
     if (response.error) throw new Error(response.error);
 
@@ -74,6 +81,8 @@ async function removeCartItem(cartItemId, productVariantId) {
       cartItemId,
       productVariantId,
     });
+
+    await trackVariantQuantityOnCart(productVariantId);
   } catch (error) {
     notify(error.message, 'error');
   } finally {
@@ -97,6 +106,7 @@ async function updateCartItem(cartItemId, productVariantId, quantity) {
       quantity,
     });
     await updateCartDrawer();
+    await trackVariantQuantityOnCart(productVariantId);
   } catch (error) {
     notify(error.message, 'error');
   } finally {
@@ -105,7 +115,14 @@ async function updateCartItem(cartItemId, productVariantId, quantity) {
   }
 }
 
-function increaseCartQuantity(cartItemId, productVariantId) {
+function increaseCartQuantity(cartItemId, productVariantId, inventory) {
+  const input = document.querySelector(`#quantity-${cartItemId}`);
+  const currentQuantity = parseInt(input.value);
+
+  if (inventory && (currentQuantity >= inventory)) {
+    return notify(ADD_TO_CART_EXPECTED_ERRORS.max_quantity + inventory, 'warning');
+  }
+
   updateCartQuantity(cartItemId, productVariantId, 1);
 }
 
@@ -115,8 +132,10 @@ function decreaseCartQuantity(cartItemId, productVariantId) {
 
 function updateCartQuantity(cartItemId, productVariantId, delta) {
   const input = document.querySelector(`#quantity-${cartItemId}`);
+
   if (input) {
     const newQuantity = parseInt(input.value) + delta;
+
     if (newQuantity >= 1) {
       input.value = newQuantity;
       updateCartItem(cartItemId, productVariantId, newQuantity);
@@ -133,6 +152,7 @@ function cartTemplate(item) {
     }
   }
   const variationsString = variationsArray.join('<br/>');
+  const variantInventory = item.productVariant.product.track_inventory ? item.productVariant.inventory : null;
 
   let variationsCheck = ''
   if (variationsString === 'default: default') {
@@ -161,7 +181,7 @@ function cartTemplate(item) {
         <div class="left-items">
           <div class="product-price">
             ${
-              item.productVariant.compare_at_price ? 
+              item.productVariant.compare_at_price ?
               `<span class="compare-price">${item.productVariant.compare_at_price}</span>` : ''
             }
             <div class="currency-wrapper">
@@ -174,9 +194,9 @@ function cartTemplate(item) {
           <div class="spinner" data-spinner-id="${item.id}" style="display: none;"></div>
           <!--
             <div class="quantity-control">
-              <button class="increase-btn cart-quantity-btn" onclick="increaseCartQuantity('${item.id}', '${item.productVariant.id}')">+</button>
-              <input type="number" id="quantity-${item.id}" value="${item.quantity}" min="1" onchange="updateCartItem('${item.id}', '${item.productVariant.id}', this.value)">
-              <button class="decrease-btn cart-quantity-btn" onclick="decreaseCartQuantity('${item.id}', '${item.productVariant.id}')">-</button>
+              <button class="increase-btn cart-quantity-btn" onclick="increaseCartQuantity('${item.id}', '${item.productVariant.id}', , '${variantInventory}')">+</button>
+              <input type="number" id="quantity-${item.id}" value="${item.quantity}" min="1" onchange="updateCartItem('${item.id}', '${item.productVariant.id}', this.value)" oninput="restrictInputValue(event.target, ${variantInventory})">
+              <button class="decrease-btn cart-quantity-btn" onclick="decreaseCartQuantity('${item.id}', '${item.productVariant.id}', , '${variantInventory}')">-</button>
             </div>
           -->
         </div>
@@ -220,7 +240,7 @@ async function updateCartDrawer() {
         if (item.productVariant.compare_at_price) {
           const usePrecision = shouldUsePrecision(item.productVariant.compare_at_price);
           item.productVariant.compare_at_price = formatCurrency(
-            item.productVariant.compare_at_price, 
+            item.productVariant.compare_at_price,
             currencyCode,
             customerLocale,
           );
@@ -348,13 +368,22 @@ function preventCartDrawerOpening(templateName) {
   window.location.reload();
 }
 
-async function directAddToCart(event, productId) {
+async function directAddToCart(event, productId, inventory) {
   event.preventDefault();
+
+  await trackVariantQuantityOnCart(productId);
+
+  const variantQuantityInCart = parseInt(document.querySelector('#cartQuantity')?.value) || null;
+  const newQuantity = 1;
+
+  if (Number.isFinite(inventory) && ((variantQuantityInCart ?? 0) + newQuantity) > inventory) {
+    return notify(ADD_TO_CART_EXPECTED_ERRORS.max_quantity + inventory, 'warning');
+  }
 
   try {
     const response = await youcanjs.cart.addItem({
       productVariantId: productId,
-      quantity: 1
+      quantity: newQuantity
     });
 
     if (response.error) throw new Error(response.error);

--- a/themes/harmony/assets/cart.js
+++ b/themes/harmony/assets/cart.js
@@ -90,23 +90,22 @@ async function removeCoupons(e) {
   }
 }
 
-function updateCart(item, quantity, totalPriceSelector, cartItemId, productVariantId) {
+function updateCart(item, quantity, totalPriceSelector, cartItemId, productVariantId, inventory) {
   const inputHolder = document.getElementById(item);
   const input = inputHolder.querySelector(`input[id="${productVariantId}"]`);
   input.value = quantity;
   const decrease = input.previousElementSibling;
   const increase = input.nextElementSibling;
-
   const productPrice = inputHolder.querySelector('.product-price');
   const price = productPrice.innerText;
   const totalPrice = inputHolder.querySelector(totalPriceSelector);
 
   decrease
     .querySelector('button')
-    .setAttribute('onclick', `decreaseQuantity('${cartItemId}', '${productVariantId}', '${Number(quantity) - 1}')`);
+    .setAttribute('onclick', `decreaseQuantity('${cartItemId}', '${productVariantId}', '${Number(quantity) - 1}', ${inventory})`);
   increase
     .querySelector('button')
-    .setAttribute('onclick', `increaseQuantity('${cartItemId}', '${productVariantId}', '${Number(quantity) + 1}')`);
+    .setAttribute('onclick', `increaseQuantity('${cartItemId}', '${productVariantId}', '${quantity}', ${inventory})`);
 
   if (isNaN(quantity)) {
     totalPrice.innerText = 0;
@@ -143,16 +142,16 @@ document.addEventListener('DOMContentLoaded', () => {
   fetchCoupons();
 });
 
-function updateDOM(cartItemId, productVariantId, quantity) {
-  updateCart(cartItemId, quantity, '.total-price', cartItemId, productVariantId);
+function updateDOM(cartItemId, productVariantId, quantity, inventory) {
+  updateCart(cartItemId, quantity, '.total-price', cartItemId, productVariantId, inventory);
   updateTotalPrice();
 }
 
-function updatePrice(cartItemUniqueId, productVariantId, quantity) {
-  updateCart(`cart-item-${cartItemUniqueId}`, quantity, '.item-price', cartItemUniqueId, productVariantId);
+function updatePrice(cartItemUniqueId, productVariantId, quantity, inventory) {
+  updateCart(`cart-item-${cartItemUniqueId}`, quantity, '.item-price', cartItemUniqueId, productVariantId, inventory);
 }
 
-async function updateQuantity(cartItemId, productVariantId, quantity) {
+async function updateQuantity(cartItemId, productVariantId, quantity, inventory) {
   load(`#loading__${cartItemId}`);
   try {
     await youcanjs.cart.updateItem({ cartItemId, productVariantId, quantity });
@@ -162,28 +161,32 @@ async function updateQuantity(cartItemId, productVariantId, quantity) {
     stopLoad(`#loading__${cartItemId}`);
   }
 
-  updateDOM(cartItemId, productVariantId, quantity);
-  updatePrice(cartItemId,productVariantId,quantity);
+  updateDOM(cartItemId, productVariantId, quantity, inventory);
+  updatePrice(cartItemId,productVariantId,quantity, inventory);
   updateTotalPrice();
 }
 
-async function updateOnchange(cartItemId, productVariantId) {
+async function updateOnchange(cartItemId, productVariantId, inventory) {
   const inputHolder = document.getElementById(cartItemId);
   const input = inputHolder.querySelector(`input[id="${productVariantId}"]`);
   const quantity = input.value;
 
-  await updateQuantity(cartItemId, productVariantId, quantity);
+  await updateQuantity(cartItemId, productVariantId, quantity, inventory);
 }
 
-async function decreaseQuantity(cartItemId, productVariantId, quantity) {
-  if (quantity < 1) {
+async function decreaseQuantity(cartItemId, productVariantId, quantity, inventory) {
+  if (Number(quantity) < 1) {
     return;
   }
-  await updateQuantity(cartItemId, productVariantId, quantity);
+  await updateQuantity(cartItemId, productVariantId, quantity, inventory);
 }
 
-async function increaseQuantity(cartItemId, productVariantId, quantity) {
-  await updateQuantity(cartItemId, productVariantId, quantity);
+async function increaseQuantity(cartItemId, productVariantId, quantity, inventory) {
+  if (Number.isFinite(inventory) && (Number(quantity) >= inventory)) {
+    return notify(ADD_TO_CART_EXPECTED_ERRORS.max_quantity + inventory, 'warning');
+  }
+
+  await updateQuantity(cartItemId, productVariantId, (Number(quantity) + 1), inventory);
 }
 
 function updateCartItemCount(count) {

--- a/themes/harmony/assets/dropdown-menu.js
+++ b/themes/harmony/assets/dropdown-menu.js
@@ -1,8 +1,10 @@
+let isDropDownOpened = false;
 /**
  * @param {HTMLElement} element
  */
 function showDropDownMenu(element) {
   element.classList.toggle('show');
+  isDropDownOpened = true;
 }
 
 /**
@@ -12,6 +14,7 @@ function showDropDownMenu(element) {
 function hideDropDownMenu(element, event)  {
   if (!event.target.matches('.dropbtn, .dropbtn *')) {
     element?.classList.remove('show');
+    isDropDownOpened = false;
   }
 }
 
@@ -43,7 +46,11 @@ function dropdownMenu() {
     const dropdownContent = dropDownInput.querySelector('.dropdown-content');
 
     selectInput.addEventListener('click', () => showDropDownMenu(dropdownContent));
-    window.addEventListener('click', (event) => hideDropDownMenu(dropdownContent, event));
+    document.addEventListener('click', (event) => {
+      if(isDropDownOpened) {
+        hideDropDownMenu(dropdownContent, event);
+      }
+    });
 
     const selectOptions = dropdownContent.querySelectorAll('li');
 
@@ -62,5 +69,4 @@ function dropdownMenu() {
     });
   });
 }
-
 dropdownMenu();

--- a/themes/harmony/assets/express-checkout.css
+++ b/themes/harmony/assets/express-checkout.css
@@ -94,6 +94,10 @@
   font-family:inherit;
   font-weight:bold;
 }
+.express-checkout-button:disabled{
+  opacity:0.5;
+  cursor:not-allowed;
+}
 .express-checkout-button span{
   font-family:inherit;
   font-weight:inherit;
@@ -213,11 +217,6 @@
   .yc-sticky-checkout .sticky-desktop-wrapper .checkout-form{
     padding-bottom:0;
   }
-}
-
-.sticky-checkout-placeholder .express-checkout-button:disabled{
-  opacity:0.5;
-  cursor:not-allowed;
 }
 
 .sticky-btn-placehodler{

--- a/themes/harmony/assets/express-checkout.js
+++ b/themes/harmony/assets/express-checkout.js
@@ -30,7 +30,6 @@ async function placeOrder() {
           const formField = form.querySelector(`[name="${fieldName}"]`);
           const errorEl = form.querySelector(`.validation-error[data-error="${fieldName}"]`);
           if (formField) {
-            console.log(formField);
             formField.classList.add('error');
           }
 

--- a/themes/harmony/assets/main.css
+++ b/themes/harmony/assets/main.css
@@ -504,6 +504,9 @@ textarea{
 .yc-alert.error{
   background-color:var(--yc-error-color);
 }
+.yc-alert.warning{
+  background-color:var(--yc-warning-color);
+}
 .yc-alert.show{
   opacity:1;
   z-index:9999;

--- a/themes/harmony/assets/main.js
+++ b/themes/harmony/assets/main.js
@@ -367,7 +367,6 @@ function shouldUsePrecision(amount) {
   return isMulticurrencyActive && usePrecision;
 }
 
-
 /**
  * Restrict the input value based on the inventory number
  *

--- a/themes/harmony/assets/main.js
+++ b/themes/harmony/assets/main.js
@@ -399,6 +399,8 @@ function restrictInputValue(inputElement, maxInventoryValue) {
 async function trackVariantQuantityOnCart(selectedVariantId) {
   try {
     load('#loading__cart');
+    const cartQuantityInput = document.querySelector('#cartQuantity');
+    cartQuantityInput.value = 0;
     const cart = await youcanjs.cart.fetch();
 
     if (!cart) {
@@ -410,7 +412,6 @@ async function trackVariantQuantityOnCart(selectedVariantId) {
     }
 
     const cartItem = cart.items.find((item) => item.productVariant.id === selectedVariantId);
-    const cartQuantityInput = document.querySelector('#cartQuantity');
 
     if (!cartItem || cartItem.productVariant.product.track_inventory === false) {
       return;

--- a/themes/harmony/assets/main.js
+++ b/themes/harmony/assets/main.js
@@ -34,12 +34,22 @@ if (fixedNavbar && notice) {
 /* ----- spinner-loader ----- */
 /* -------------------------- */
 function load(el) {
-  const loader = document.querySelector(el);
-  if (loader) {
-    loader.classList.remove('hidden');
+  const element = document.querySelector(el);
+
+  if (!element) {
+    return;
   }
 
-  const nextEl = loader ? loader.nextElementSibling : null;
+  if (element) {
+    element.classList.remove('hidden');
+  }
+
+  if (element.parentElement.hasAttribute('data-type')) {
+    element.parentElement.setAttribute('data-type', 'loading');
+    element.parentElement.disabled = true;
+  }
+
+  const nextEl = element ? element.nextElementSibling : null;
 
   if (nextEl) {
     nextEl.classList.add('hidden');
@@ -47,12 +57,22 @@ function load(el) {
 }
 
 function stopLoad(el) {
-  const loader = document.querySelector(el);
-  if (loader) {
-    loader.classList.add('hidden');
+  const element = document.querySelector(el);
+
+  if (!element) {
+    return;
   }
 
-  const nextEl = loader ? loader.nextElementSibling : null;
+  if (element) {
+    element.classList.add('hidden');
+  }
+
+  if (element.parentElement.hasAttribute('data-type')) {
+    element.parentElement.setAttribute('data-type', '');
+    element.parentElement.disabled = false;
+  }
+
+  const nextEl = element ? element.nextElementSibling : null;
   if (nextEl) {
     nextEl.classList.remove('hidden');
   }
@@ -330,7 +350,7 @@ function formatCurrency(amount, currencySymbol, locale = 'en-US') {
 
   const parts = determineSymbolPositionFormatter.formatToParts(1); // format with 1 USD just to determine the position of the currency symbol
   const symbolIndex = parts.findIndex(part => part.type === 'currency');
-  
+
   return symbolIndex === 0
     ? `${currencySymbol} ${formattedValue}`
     : `${formattedValue} ${currencySymbol}`;
@@ -345,4 +365,61 @@ function shouldUsePrecision(amount) {
   }
 
   return isMulticurrencyActive && usePrecision;
+}
+
+
+/**
+ * Restrict the input value based on the inventory number
+ *
+ * @param {HTMLInputElement} inputElement - The input element.
+ * @param {number} maxInventoryValue - The maximum allowable inventory value.
+ */
+function restrictInputValue(inputElement, maxInventoryValue) {
+
+  if (maxInventoryValue === null) {
+    return;
+  }
+
+  let currentValue = parseInt(inputElement.value);
+
+  if (currentValue < 1) {
+    inputElement.value = 1;
+  }
+
+  if (currentValue > maxInventoryValue) {
+    inputElement.value = maxInventoryValue;
+  }
+}
+
+/**
+ * Tracks the quantity of a specific variant in the cart and set it in the hidden quantity input.
+ *
+ * @param {string} selectedVariantId - The ID of the selected product variant.
+ */
+async function trackVariantQuantityOnCart(selectedVariantId) {
+  try {
+    load('#loading__cart');
+    const cart = await youcanjs.cart.fetch();
+
+    if (!cart) {
+      return;
+    }
+
+    if (cart.items.length === 0 || cart.items.data?.length === 0) {
+      return;
+    }
+
+    const cartItem = cart.items.find((item) => item.productVariant.id === selectedVariantId);
+    const cartQuantityInput = document.querySelector('#cartQuantity');
+
+    if (!cartItem || cartItem.productVariant.product.track_inventory === false) {
+      return;
+    }
+
+    cartQuantityInput.value = cartItem.quantity;
+  } catch(e) {
+    notify(e.message, 'error');
+  } finally {
+    stopLoad('#loading__cart');
+  }
 }

--- a/themes/harmony/assets/product-quantity-input.js
+++ b/themes/harmony/assets/product-quantity-input.js
@@ -5,6 +5,7 @@ function manipulateQuantity() {
   const decrementButton = $('.decrement-button');
   const incrementButton = $('.increment-button');
   const quantityInput = $('.quantity-input');
+  const inventoryInput = $('#_inventory');
 
   /**
    * Decreases quantity value by 1 when decrement button is clicked
@@ -21,7 +22,21 @@ function manipulateQuantity() {
    */
   incrementButton?.addEventListener('click', () => {
     const currentValue = parseInt(quantityInput.value);
+    const inventory = parseInt(inventoryInput.value);
+
+    if(Number.isFinite(inventory) && currentValue >= inventory) {
+      return notify(ADD_TO_CART_EXPECTED_ERRORS.max_quantity + inventory, 'warning');
+    }
+
     quantityInput.value = currentValue + 1;
+  });
+
+  /**
+   * Check if the current value exceeds the max inventory
+   */
+  quantityInput?.addEventListener('input', () => {
+    const maxInventoryValue = parseInt(inventoryInput.value);
+    restrictInputValue(quantityInput, maxInventoryValue);
   });
 }
 

--- a/themes/harmony/locales/ar.default.json
+++ b/themes/harmony/locales/ar.default.json
@@ -153,7 +153,8 @@
     "quantity_smaller_than_zero": "يجب أن تكون الكمية أكبر من 0",
     "upload_image": "الرجاء تحميل صورة",
     "product_added": "تمت إضافة المنتج بنجاح",
-    "empty_inventory": "المُنتج غير متوفر حاليًا في المخزون"
+    "empty_inventory": "المُنتج غير متوفر حاليًا في المخزون",
+    "max_quantity": "الكمية المتاحة لهذا العرض هي: "
   },
   "page": {
     "contact": {

--- a/themes/harmony/locales/en.json
+++ b/themes/harmony/locales/en.json
@@ -153,7 +153,8 @@
     "quantity_smaller_than_zero": "Quantity must be greater than 0",
     "upload_image": "Please upload an image",
     "product_added": "Product has been added successfully",
-    "empty_inventory": "Product out of stock"
+    "empty_inventory": "Product out of stock",
+    "max_quantity": "The available quantity for this variant is: "
   },
   "page": {
     "contact": {

--- a/themes/harmony/locales/fr.json
+++ b/themes/harmony/locales/fr.json
@@ -153,7 +153,8 @@
     "quantity_smaller_than_zero": "La quantité doit être supérieure à 0",
     "upload_image": "Veuillez télécharger une image",
     "product_added": "Produit ajouté avec succès",
-    "empty_inventory": "Produit en rupture de stock"
+    "empty_inventory": "Produit en rupture de stock",
+    "max_quantity": "La quantité disponible pour cette variante est : "
   },
   "page": {
     "contact": {

--- a/themes/harmony/snippets/add-to-cart.liquid
+++ b/themes/harmony/snippets/add-to-cart.liquid
@@ -21,6 +21,8 @@
 
 <div class='yc-{{ uniq }}-add-to-cart{% if block_settings.is_sticky %} is_sticky{% endif %} add-to-cart-btn'>
   <button
+    class="add-to-cart-button"
+    data-type=""
     onclick='addToCart("{{ snippetId }}")'
     {% if is_placeholder %} disabled {% endif %}
   >

--- a/themes/harmony/snippets/alert.liquid
+++ b/themes/harmony/snippets/alert.liquid
@@ -7,5 +7,9 @@
     name='checkmark-circle-outline'
     class='text-xl icon-success icon'
   ></ion-icon>
+  <ion-icon
+    name="warning-outline"
+    class='text-xl icon-warning icon'
+  ></ion-icon>
   <span class='alert-msg text-white'> Some context </span>
 </div>

--- a/themes/harmony/snippets/cart-drawer.liquid
+++ b/themes/harmony/snippets/cart-drawer.liquid
@@ -1,5 +1,6 @@
 {{ 'cart-drawer.css' | asset_url | stylesheet_tag }}
 
+<input id='cartQuantity' type='hidden'>
 <div class="cart-overlay"></div>
 <div class="cart-drawer">
   <button class="cart-drawer__close" aria-label="close cart">
@@ -18,7 +19,8 @@
     quantity_smaller_than_zero: "{{ 'errors.quantity_smaller_than_zero' | t }}",
     upload_image: "{{ 'errors.upload_image' | t }}",
     product_added: "{{ 'errors.product_added' | t }}",
-    empty_inventory: "{{ 'errors.empty_inventory' | t }}"
+    empty_inventory: "{{ 'errors.empty_inventory' | t }}",
+    max_quantity: "{{ 'errors.max_quantity' | t }}",
   }
 
   const CART_DRAWER_TRANSLATION = {

--- a/themes/harmony/snippets/product-preview.liquid
+++ b/themes/harmony/snippets/product-preview.liquid
@@ -36,7 +36,7 @@
     </div>
     <div class='product-btn'>
       {% if settings.direct_add_to_cart and item.variants.size <= 1 %}
-        <button class="yc-btn-secondary" onclick="directAddToCart(event, '{{ item.variants[0].id }}')">
+        <button class="yc-btn-secondary" onclick="directAddToCart(event, '{{ item.variants[0].id }}', {{ item.variants[0].inventory }})">
           {{ 'general.direct_add_to_cart' | t }}
         </button>
       {% else %}

--- a/themes/harmony/snippets/product-preview.liquid
+++ b/themes/harmony/snippets/product-preview.liquid
@@ -36,7 +36,7 @@
     </div>
     <div class='product-btn'>
       {% if settings.direct_add_to_cart and item.variants.size <= 1 %}
-        <button class="yc-btn-secondary" onclick="directAddToCart(event, '{{ item.variants[0].id }}', {{ item.variants[0].inventory }})">
+        <button class="yc-btn-secondary" onclick="directAddToCart(event, '{{ item.variants[0].id }}', {{ item.variants[0].inventory }}, {{ item.isTrackingInventory }})">
           {{ 'general.direct_add_to_cart' | t }}
         </button>
       {% else %}

--- a/themes/harmony/snippets/product-slider.liquid
+++ b/themes/harmony/snippets/product-slider.liquid
@@ -48,8 +48,8 @@
             <a href='{{ block.settings.product.url }}' class='product-block'>
               <div class="product-slider">
                 <div class='product-thumbnail'>
-                  <img 
-                    loading='lazy' 
+                  <img
+                    loading='lazy'
                     src='{%- if block.settings.product.thumbnail -%} {{ block.settings.product.thumbnail }} {%- else -%} {{ 'default_product.jpeg' | asset_url }} {%- endif -%}'
                     alt='{{ block.settings.product.name }}'
                   >
@@ -70,7 +70,7 @@
                     {% endif %}
                   </div>
                   {% if settings.direct_add_to_cart and block.settings.product.variants.size <= 1 %}
-                    <button class="yc-btn-secondary--large" onclick="directAddToCart(event, '{{ block.settings.product.variants[0].id }}');">
+                    <button class="yc-btn-secondary--large" onclick="directAddToCart(event, '{{ block.settings.product.variants[0].id }}', {{ block.settings.product.variants[0].inventory }});">
                       {{ 'general.direct_add_to_cart' | t }}
                     </button>
                   {% else %}

--- a/themes/harmony/snippets/product-slider.liquid
+++ b/themes/harmony/snippets/product-slider.liquid
@@ -70,7 +70,7 @@
                     {% endif %}
                   </div>
                   {% if settings.direct_add_to_cart and block.settings.product.variants.size <= 1 %}
-                    <button class="yc-btn-secondary--large" onclick="directAddToCart(event, '{{ block.settings.product.variants[0].id }}', {{ block.settings.product.variants[0].inventory }});">
+                    <button class="yc-btn-secondary--large" onclick="directAddToCart(event, '{{ block.settings.product.variants[0].id }}', {{ block.settings.product.variants[0].inventory }}, {{ block.settings.product.isTrackingInventory }})">
                       {{ 'general.direct_add_to_cart' | t }}
                     </button>
                   {% else %}

--- a/themes/harmony/snippets/quantity-input.liquid
+++ b/themes/harmony/snippets/quantity-input.liquid
@@ -1,18 +1,19 @@
 <div class='quantity-wrapper'>
   <div class='decrease'>
-    <button onclick="decreaseQuantity('{{ item.id }}', '{{ item.product_variant_id }}', '{{ item.quantity | minus: 1 }}')">
+    <button onclick="decreaseQuantity('{{ item.id }}', '{{ item.product_variant_id }}', '{{ item.quantity | minus: 1 }}', {{ item.inventory }})">
       -
     </button>
   </div>
   <input
-    onchange="updateOnchange('{{ item.id }}', '{{ item.product_variant_id }}')"
+    onchange="updateOnchange('{{ item.id }}', '{{ item.product_variant_id }}', {{ item.inventory }})"
+    oninput="restrictInputValue(event.target, {{ item.inventory }})"
     type='text'
     value='{{ item.quantity }}'
     id='{{ item.product_variant_id }}'
     aria-label="quantity"
   >
   <div class='increase'>
-    <button onclick="increaseQuantity('{{ item.id }}', '{{ item.product_variant_id }}', '{{ item.quantity | plus: 1 }}')">
+    <button onclick="increaseQuantity('{{ item.id }}', '{{ item.product_variant_id }}', '{{ item.quantity | plus: 1 }}', {{ item.inventory }})">
       +
     </button>
   </div>

--- a/themes/harmony/snippets/quantity-input.liquid
+++ b/themes/harmony/snippets/quantity-input.liquid
@@ -13,7 +13,7 @@
     aria-label="quantity"
   >
   <div class='increase'>
-    <button onclick="increaseQuantity('{{ item.id }}', '{{ item.product_variant_id }}', '{{ item.quantity | plus: 1 }}', {{ item.inventory }})">
+    <button onclick="increaseQuantity('{{ item.id }}', '{{ item.product_variant_id }}', '{{ item.quantity }}', {{ item.inventory }})">
       +
     </button>
   </div>

--- a/themes/harmony/styles/express-checkout.scss
+++ b/themes/harmony/styles/express-checkout.scss
@@ -97,6 +97,11 @@
   font-family: inherit;
   font-weight: bold;
 
+  &:disabled {
+    opacity: 0.5;
+    cursor: not-allowed;
+  }
+
   span {
     font-family: inherit;
     font-weight: inherit;
@@ -220,13 +225,6 @@
         padding-bottom: 0;
       }
     }
-  }
-}
-
-.sticky-checkout-placeholder {
-  .express-checkout-button:disabled {
-    opacity: 0.5;
-    cursor: not-allowed;
   }
 }
 

--- a/themes/harmony/styles/main.scss
+++ b/themes/harmony/styles/main.scss
@@ -559,6 +559,10 @@ textarea {
     background-color: var(--yc-error-color);
   }
 
+  &.warning {
+    background-color: var(--yc-warning-color);
+  }
+
   &.show {
     opacity: 1;
     z-index: 9999;


### PR DESCRIPTION
## JIRA Ticket

Ticket: [TH_109](https://youcanshop.atlassian.net/browse/TH-109)

## Prerequisites

* [ ] Check this branch locally and run `pnpm run release`
* [ ] 3 new files will be generated in this format `theme name + date + .zip`
* [ ] Upload generated file locally or in seller-area test env

## QA Steps
    
There are two different scenarios to test this PR:

1- Direct add to cart:
 
- [ ]  To activate this feature:
     -> On store admin under: Store > theme > Product settings > Advanced > direct add to cart
     -> Now theme editor: Theme settings > general settings > direct add to cart

- [ ] On store admin > Products > all products > create a product or select one that doesn't have variants
- [ ] Now activate `track inventory` feature on him and set a number
- [ ] To test this feature that's working good make sure that this product is visible on the home page of your store front for example (you can do that from theme editor by adding it on a product slider section)
- [ ] After you clicking on the product you should see that the cart drawer is open and your product is in your cart (if the stock is out you will see a warning popup notification)

        
2- Normal mode:

- [ ] First make sure that you have activated `track inventory` on your product.
- [ ] Set the tracking inventory number on a product (if it have variants scroll down open the variants accordion, under the `Untracked` input set a number on each variant.
- [ ] Now under the product page of your store front try to choose a higher stock than the available you will see a popup notification warning or if the stock is 0 you won't even be able to click on the add to cart button or express checkout button as well you will see them disabled.
- [ ] We also have the ability to see the single product section on the home page you can test the same thing again.
- [ ] The behaviour that you expect to happen when you have a product that have many variants based on its own inventory you supposed to see this:
       - variant has 0 inventory: express checkout & cart buttons are disabled
       - variant has 2 on inventory :  max quantity that the customer can add to cart is 2 if try to add more the popup notification warning show up
       - variant has 2 on inventory and 2 on cart:  the popup notification warning show up

**_PS_**: Make sure to test also the cart drawer and the cart page in both scenarios => changing the variant quantity.
