### PR TITLE
DARK: aura > fix tracking inventory issue with direct add to cart method

### DIFF
--- a/themes/aura/assets/add-to-cart.js
+++ b/themes/aura/assets/add-to-cart.js
@@ -64,9 +64,11 @@ function attachRemoveItemListeners() {
       const cartItemId = event.target.getAttribute('data-cart-item-id');
       const productVariantId = event.target.getAttribute('data-product-variant-id');
 
-      await removeCartItem(cartItemId, productVariantId);
-      await updateCartDrawer();
-      updateCartCount(-1, true);
+      if(cartItemId && productVariantId) {
+        await removeCartItem(cartItemId, productVariantId);
+        await updateCartDrawer();
+        updateCartCount(-1, true);
+      }
     })
   );
 }
@@ -169,7 +171,7 @@ function cartTemplate(item) {
           </div>
           <div class="product-price">
           ${
-            item.productVariant.compare_at_price ? 
+            item.productVariant.compare_at_price ?
             `<span class="compare-price">${item.productVariant.compare_at_price}</span>` : ''
           }
             <div class="currency-wrapper">
@@ -225,10 +227,10 @@ async function updateCartDrawer() {
       for (const item of cartData.items) {
         item.price = formatCurrency(item.price, currencyCode, customerLocale);
         item.productVariant.price = formatCurrency(item.productVariant.price, currencyCode, customerLocale);
-        
+
         if (item.productVariant.compare_at_price) {
           item.productVariant.compare_at_price = formatCurrency(
-            item.productVariant.compare_at_price, 
+            item.productVariant.compare_at_price,
             currencyCode,
             customerLocale,
           );
@@ -356,13 +358,14 @@ function preventCartDrawerOpening(templateName) {
   window.location.reload();
 }
 
-async function directAddToCart(productId, inventory) {
+async function directAddToCart(productId, inventory, isTrackingInventory) {
   await trackVariantQuantityOnCart(productId);
 
   const variantQuantityInCart = parseInt(document.querySelector('#cartQuantity')?.value) || null;
+  const isTrackingInventoryAvailable = Boolean(isTrackingInventory) && Number.isFinite(inventory);
   const newQuantity = 1;
 
-  if (Number.isFinite(inventory) && ((variantQuantityInCart ?? 0) + newQuantity) > inventory) {
+  if (isTrackingInventoryAvailable && ((variantQuantityInCart ?? 0) + newQuantity) > inventory) {
     return notify(ADD_TO_CART_EXPECTED_ERRORS.max_quantity + inventory, 'warning');
   }
 

--- a/themes/aura/assets/main.js
+++ b/themes/aura/assets/main.js
@@ -398,6 +398,8 @@ function restrictInputValue(inputElement, maxInventoryValue) {
 async function trackVariantQuantityOnCart(selectedVariantId) {
   try {
     load('#loading__cart');
+    const cartQuantityInput = document.querySelector('#cartQuantity');
+    cartQuantityInput.value = 0;
     const cart = await youcanjs.cart.fetch();
 
     if (!cart) {
@@ -409,7 +411,6 @@ async function trackVariantQuantityOnCart(selectedVariantId) {
     }
 
     const cartItem = cart.items.find((item) => item.productVariant.id === selectedVariantId);
-    const cartQuantityInput = document.querySelector('#cartQuantity');
 
     if (!cartItem || cartItem.productVariant.product.track_inventory === false) {
       return;

--- a/themes/aura/snippets/product-preview.liquid
+++ b/themes/aura/snippets/product-preview.liquid
@@ -2,7 +2,7 @@
 {{ 'countdown.css' | asset_url | stylesheet_tag }}
 
 {% if settings.direct_add_to_cart and item.variants.size <= 1 %}
-  <div class='product-block' onclick="directAddToCart('{{ item.variants[0].id }}', {{ item.variants[0].inventory }})">
+  <div class='product-block' onclick="directAddToCart('{{ item.variants[0].id }}', {{ item.variants[0].inventory }}, {{ item.isTrackingInventory }})">
 {% else %}
   <div class='product-block' onclick="window.location.href='{{ item.url }}'">
 {% endif %}

--- a/themes/aura/snippets/product-slider.liquid
+++ b/themes/aura/snippets/product-slider.liquid
@@ -61,7 +61,7 @@
             {{ block.youcan_attributes }}
           >
             {% if settings.direct_add_to_cart and block.settings.product.variants.size <= 1 %}
-              <div class='product-block' onclick="directAddToCart('{{ block.settings.product.variants[0].id }}', {{ block.settings.product.variants[0].inventory }})">
+              <div class='product-block' onclick="directAddToCart('{{ block.settings.product.variants[0].id }}', {{ block.settings.product.variants[0].inventory }}, {{ block.settings.product.isTrackingInventory }})">
             {% else %}
               <div class='product-block' onclick="window.location.href='{{ block.settings.product.url }}'">
             {% endif %}

--- a/themes/aura/snippets/quantity-input.liquid
+++ b/themes/aura/snippets/quantity-input.liquid
@@ -13,7 +13,7 @@
     aria-label="quantity"
   >
   <div class='increase'>
-    <button onclick="increaseQuantity('{{ item.id }}', '{{ item.product_variant_id }}', '{{ item.quantity | plus: 1 }}', {{ item.inventory }})">
+    <button onclick="increaseQuantity('{{ item.id }}', '{{ item.product_variant_id }}', '{{ item.quantity }}', {{ item.inventory }})">
       +
     </button>
   </div>


### PR DESCRIPTION
## Prerequisites

* [ ] Check this branch locally and run `pnpm run release`
* [ ] 3 new files will be generated in this format `theme name + date + .zip`
* [ ] Upload generated file locally or in seller-area test env

## QA Steps

* [ ] Activate add to cart from theme editor
* [ ] One product has tracking inventory activated and one is not
* [ ] Add those two products in a product slider section from the theme editor
* [ ] test the one that has not tracked inventory can be added into the cart infinitely and the one that has it activated have a limit number only

## Note

This fix is also pushed in this [PR](https://github.com/youcan-shop/youcan-themes/pull/65) for harmony theme
