### PR TITLE
TH-175: Aura > Remove repetitive "quantity" label from cart drawer

### DIFF
--- a/themes/aura/assets/add-to-cart.js
+++ b/themes/aura/assets/add-to-cart.js
@@ -166,9 +166,6 @@ function cartTemplate(item) {
         ${imageUrl && `<img src="${imageUrl}" alt="${item.productVariant.product.name}" />`}
         <div class="item-details">
           <p class="product-name">${item.productVariant.product.name}</p>
-          <div class="variants">
-          ${CART_DRAWER_TRANSLATION.quantityVariant}: ${item.quantity} <br/> ${variationsCheck}
-          </div>
           <div class="product-price">
           ${
             item.productVariant.compare_at_price ?


### PR DESCRIPTION
## JIRA Ticket

Ticket: [TH_175](https://youcanshop.atlassian.net/browse/TH_175).

## Prerequisites

* [ ] Check this branch locally and run `pnpm run release`
* [ ] 3 new files will be generated in this format `theme name + date + .zip`
* [ ] Upload generated file locally or in seller-area test env

## QA Steps

* [ ] Go to https://seller-area.youcan.shop/admin/themes
* [ ] Try to active `Aura` theme
* [ ] You can see the cart item without repetitive `quantity` labels:

<img width="400" alt="Screenshot 2024-10-21 at 11 49 17" src="https://github.com/user-attachments/assets/66b37c4a-68d6-44d7-91c4-5f2c0818c12d">


## Note

Leave empty when you have nothing to say.
