### PR TITLE
DARK : Fix express checkout block CSS

### DIFF
--- a/themes/aura/assets/express-checkout.css
+++ b/themes/aura/assets/express-checkout.css
@@ -14,10 +14,7 @@
 }
 
 .express-checkout-fields{
-  border-width:2px;
-  border-style:solid;
   background:#F8F8F8;
-  box-shadow:1px -1px 23px rgba(0, 0, 0, 0.04);
   border-radius:4px;
   display:grid;
   grid-template-columns:1fr;
@@ -26,12 +23,8 @@
 }
 @media (min-width: 768px){
   .express-checkout-fields{
-    border:medium none currentcolor;
-    border:initial;
     background:transparent none repeat 0 0 / auto auto padding-box border-box scroll;
     background:initial;
-    box-shadow:none;
-    box-shadow:initial;
     padding:0;
     padding:initial;
   }
@@ -198,14 +191,4 @@
   .yc-sticky-checkout .sticky-desktop-wrapper .checkout-form{
     padding-bottom:0;
   }
-}
-
-.sticky-checkout-placeholder .express-checkout-button:disabled{
-  opacity:0.5;
-  cursor:not-allowed;
-}
-
-.sticky-btn-placehodler{
-  opacity:0.5;
-  cursor:not-allowed;
 }

--- a/themes/aura/snippets/express-checkout.liquid
+++ b/themes/aura/snippets/express-checkout.liquid
@@ -13,8 +13,7 @@
     }
   {% endif %}
 
-  .custom-checkout-{{ checkout_id }},
-  .express-checkout-fields {
+  .custom-checkout-{{ checkout_id }} {
     border: 1px solid {{ settings.form_border_colour.hex }};
   }
 
@@ -22,8 +21,8 @@
     grid-gap: {{ settings.inputs_gap }}px;
   }
 
-  .custom-checkout-{{ checkout_id }} input, 
-  .custom-checkout-{{ checkout_id }} textarea, 
+  .custom-checkout-{{ checkout_id }} input,
+  .custom-checkout-{{ checkout_id }} textarea,
   .custom-checkout-{{ checkout_id }} select {
     padding: {{ settings.input_padding }}px;
     border-radius: {{ settings.input_border_radius }}px;
@@ -74,8 +73,9 @@
   }
   {% endif %}
 
-  .express-checkout-placeholder .express-checkout-button {
-    opacity: 0.5;
+  .express-checkout-button:disabled {
+    background: #bdc3c7 !important;
+    color: #ffffff !important;
     cursor: not-allowed;
   }
 {% endstyle %}
@@ -107,19 +107,19 @@
               {% endfor %}
             </select>
           {% when 'textarea' %}
-            <textarea 
+            <textarea
               name='{{ field_name }}'
-              id='{{ field.name }}' 
-              class='w-full' 
-              placeholder='{{ field.placeholder }}' 
+              id='{{ field.name }}'
+              class='w-full'
+              placeholder='{{ field.placeholder }}'
               required='{{ field.required }}' min></textarea>
           {% else %}
-            <input 
+            <input
               name='{{ field_name }}'
-              type='{{ field.type }}' 
-              id='{{ field.name }}' 
-              class='w-full' 
-              placeholder='{{ field.placeholder }}' 
+              type='{{ field.type }}'
+              id='{{ field.name }}'
+              class='w-full'
+              placeholder='{{ field.placeholder }}'
               required='{{ field.required }}'>
         {% endcase %}
         <div

--- a/themes/aura/snippets/single-product-placeholder.liquid
+++ b/themes/aura/snippets/single-product-placeholder.liquid
@@ -45,8 +45,10 @@
           {%- when 'express_checkout' -%}
             {% render 'express-checkout', checkout: checkout, is_sticky: block.settings.is_sticky, settings: block.settings, is_placeholder: is_placeholder %}
             {% if block.settings.is_sticky %}
-            {% render 'sticky-checkout', settings: block.settings %}
-            <button class="yc-btn is_sticky {% if is_placeholder %} sticky-btn-placehodler {% endif %} font-bold express-checkout-button">{{ block.settings.express_checkout_cta }}</button>
+              {% render 'sticky-checkout', settings: block.settings %}
+                <button class="yc-btn is_sticky font-bold express-checkout-button" {% if is_placeholder %} disabled {% endif %}>
+                  {{ block.settings.express_checkout_cta }}
+                </button>
             {% endif %}
         {%- endcase -%}
     {%- endfor -%}

--- a/themes/aura/styles/express-checkout.scss
+++ b/themes/aura/styles/express-checkout.scss
@@ -19,10 +19,7 @@ $sticky-checkout-padding: 20px;
 }
 
 .express-checkout-fields {
-  border-width: 2px;
-  border-style: solid;
   background: #F8F8F8;
-  box-shadow: 1px -1px 23px rgba(0, 0, 0, 0.04);
   border-radius: 4px;
   display: grid;
   grid-template-columns: 1fr;
@@ -30,9 +27,7 @@ $sticky-checkout-padding: 20px;
   padding: 10px;
 
   @include breakpoint('md') {
-    border: unset;
     background: unset;
-    box-shadow: unset;
     padding: unset;
   }
 }
@@ -212,16 +207,4 @@ $sticky-checkout-padding: 20px;
       }
     }
   }
-}
-
-.sticky-checkout-placeholder {
-  .express-checkout-button:disabled {
-    opacity: 0.5;
-    cursor: not-allowed;
-  }
-}
-
-.sticky-btn-placehodler {
-  opacity: 0.5;
-  cursor: not-allowed;
 }

--- a/themes/harmony/assets/express-checkout.css
+++ b/themes/harmony/assets/express-checkout.css
@@ -42,7 +42,6 @@
     border-width:6px;
     border-style:solid;
     background:#F8F8F8;
-    box-shadow:1px -1px 23px rgba(0, 0, 0, 0.04);
     border-radius:4px;
     padding:20px;
     grid-gap:18px;
@@ -53,11 +52,6 @@
 }
 
 .express-checkout-fields{
-  border-width:4px;
-  border-style:solid;
-  background:#F8F8F8;
-  box-shadow:1px -1px 23px rgba(0, 0, 0, 0.04);
-  border-radius:4px;
   display:grid;
   grid-template-columns:1fr;
   grid-gap:14px;
@@ -65,13 +59,6 @@
 }
 @media (min-width: 768px){
   .express-checkout-fields{
-    border-width:4px;
-    border:medium none currentcolor;
-    border:initial;
-    background:transparent none repeat 0 0 / auto auto padding-box border-box scroll;
-    background:initial;
-    box-shadow:none;
-    box-shadow:initial;
     padding:0;
     padding:initial;
   }
@@ -217,9 +204,4 @@
   .yc-sticky-checkout .sticky-desktop-wrapper .checkout-form{
     padding-bottom:0;
   }
-}
-
-.sticky-btn-placehodler{
-  opacity:0.5;
-  cursor:not-allowed;
 }

--- a/themes/harmony/snippets/express-checkout.liquid
+++ b/themes/harmony/snippets/express-checkout.liquid
@@ -14,7 +14,6 @@
   {% endif %}
 
   .custom-checkout-{{ checkout_id }},
-  .express-checkout-fields,
   .sticky-form-wrapper {
     border: 1px solid {{ settings.form_border_colour.hex }};
   }
@@ -24,8 +23,8 @@
     grid-gap: {{ settings.inputs_gap }}px;
   }
 
-  .custom-checkout-{{ checkout_id }} input, 
-  .custom-checkout-{{ checkout_id }} textarea, 
+  .custom-checkout-{{ checkout_id }} input,
+  .custom-checkout-{{ checkout_id }} textarea,
   .custom-checkout-{{ checkout_id }} select {
     padding: {{ settings.input_padding }}px;
     border-radius: {{ settings.input_border_radius }}px;
@@ -73,7 +72,7 @@
     padding: calc({{ settings.input_padding }}px - 4px);
   }
 
-  .express-checkout-placeholder .express-checkout-button {
+  .express-checkout-button:disabled {
     opacity: 0.5;
     cursor: not-allowed;
   }
@@ -109,19 +108,19 @@
               {% endfor %}
             </select>
           {% when 'textarea' %}
-            <textarea 
+            <textarea
               name='{{ field_name }}'
-              id='{{ field.name }}' 
-              class='w-full' 
-              placeholder='{{ field.placeholder }}' 
+              id='{{ field.name }}'
+              class='w-full'
+              placeholder='{{ field.placeholder }}'
               required='{{ field.required }}' min></textarea>
           {% else %}
-            <input 
+            <input
               name='{{ field_name }}'
-              type='{{ field.type }}' 
-              id='{{ field.name }}' 
-              class='w-full' 
-              placeholder='{{ field.placeholder }}' 
+              type='{{ field.type }}'
+              id='{{ field.name }}'
+              class='w-full'
+              placeholder='{{ field.placeholder }}'
               required='{{ field.required }}'>
         {% endcase %}
         <div

--- a/themes/harmony/snippets/single-product-placeholder.liquid
+++ b/themes/harmony/snippets/single-product-placeholder.liquid
@@ -45,8 +45,10 @@
           {%- when 'express_checkout' -%}
             {% render 'express-checkout', checkout: checkout, is_sticky: block.settings.is_sticky, settings: block.settings, is_placeholder: is_placeholder %}
             {% if block.settings.is_sticky %}
-            {% render 'sticky-checkout', settings: block.settings %}
-            <button class="yc-btn is_sticky {% if is_placeholder %} sticky-btn-placehodler {% endif %} font-bold express-checkout-button">{{ block.settings.express_checkout_cta }}</button>
+              {% render 'sticky-checkout', settings: block.settings %}
+              <button class="yc-btn is_sticky font-bold express-checkout-button" {% if is_placeholder %} disabled {% endif %}>
+                {{ block.settings.express_checkout_cta }}
+              </button>
             {% endif %}
         {%- endcase -%}
     {%- endfor -%}

--- a/themes/harmony/styles/express-checkout.scss
+++ b/themes/harmony/styles/express-checkout.scss
@@ -49,7 +49,6 @@
     border-width: 6px;
     border-style: solid;
     background: #F8F8F8;
-    box-shadow: 1px -1px 23px rgba(0, 0, 0, 0.04);
     border-radius: 4px;
     padding: 20px;
     grid-gap: 18px;
@@ -61,21 +60,12 @@
 }
 
 .express-checkout-fields {
-  border-width: 4px;
-  border-style: solid;
-  background: #F8F8F8;
-  box-shadow: 1px -1px 23px rgba(0, 0, 0, 0.04);
-  border-radius: 4px;
   display: grid;
   grid-template-columns: 1fr;
   grid-gap: 14px;
   padding: 10px;
 
   @include breakpoint('md') {
-    border-width: 4px;
-    border: unset;
-    background: unset;
-    box-shadow: unset;
     padding: unset;
   }
 }
@@ -226,9 +216,4 @@
       }
     }
   }
-}
-
-.sticky-btn-placehodler {
-  opacity: 0.5;
-  cursor: not-allowed;
 }

--- a/themes/meraki/snippets/single-product-placeholder.liquid
+++ b/themes/meraki/snippets/single-product-placeholder.liquid
@@ -45,8 +45,10 @@
           {%- when 'express_checkout' -%}
             {% render 'express-checkout', checkout: checkout, is_sticky: block.settings.is_sticky, settings: block.settings, is_placeholder: is_placeholder %}
             {% if block.settings.is_sticky %}
-            {% render 'sticky-checkout', settings: block.settings %}
-            <button class="yc-btn is_sticky {% if is_placeholder %} sticky-btn-placehodler {% endif %} font-bold express-checkout-button">{{ block.settings.express_checkout_cta }}</button>
+              {% render 'sticky-checkout', settings: block.settings %}
+              <button class="yc-btn is_sticky font-bold express-checkout-button" {% if is_placeholder %} disabled {% endif %}>
+                {{ block.settings.express_checkout_cta }}
+              </button>
             {% endif %}
         {%- endcase -%}
     {%- endfor -%}


### PR DESCRIPTION
## issue
Before
<img width="605" alt="Screenshot 2024-10-21 at 14 51 59" src="https://github.com/user-attachments/assets/e235e785-69b6-490a-a5db-da13954e4e40">

After
<img width="562" alt="Screenshot 2024-10-21 at 15 14 08" src="https://github.com/user-attachments/assets/38adac16-7aaa-46b1-95dc-60043bea6311">

## Prerequisites

* [ ] Check this branch locally and run `pnpm run release`
* [ ] 3 new files will be generated in this format `theme name + date + .zip`
* [ ] Upload generated file locally or in seller-area test env

## QA Steps
* [ ] Go to seller area > All product > edit product
* [ ] First make sure that you have activated track inventory feature on your product.
* [ ] Set in the input of the tracking inventory: 0 (if it has variants scroll down and open the variants accordion, under the Untracked input set 0.
* [ ] Go to theme editor make: Product page > single product section > express checkout block
* [ ] Disable the sticky switch button
