### PR TITLE
TH-186 New themes > Express checkout > Max checkout amount error is missing

### DIFF
--- a/themes/aura/assets/express-checkout.js
+++ b/themes/aura/assets/express-checkout.js
@@ -15,7 +15,11 @@ async function placeOrder() {
     const response = await youcanjs.checkout.placeExpressCheckoutOrder({ productVariantId, quantity, fields });
 
     if (response.data.status >= 400) {
-      throw new Error(response.data.message);
+      const tempDiv = document.createElement('div');
+      tempDiv.innerHTML = response.data.message;
+
+      const errorMessage = tempDiv.innerText || tempDiv.textContent;
+      throw new Error(errorMessage);
     }
 
     response

--- a/themes/aura/assets/express-checkout.js
+++ b/themes/aura/assets/express-checkout.js
@@ -14,6 +14,10 @@ async function placeOrder() {
 
     const response = await youcanjs.checkout.placeExpressCheckoutOrder({ productVariantId, quantity, fields });
 
+    if (response.data.status >= 400) {
+      throw new Error(response.data.message);
+    }
+
     response
       .onSuccess((data, redirectToThankyouPage) => {
         redirectToThankyouPage();

--- a/themes/harmony/assets/express-checkout.js
+++ b/themes/harmony/assets/express-checkout.js
@@ -15,7 +15,11 @@ async function placeOrder() {
     const response = await youcanjs.checkout.placeExpressCheckoutOrder({ productVariantId, quantity, fields });
 
     if (response.data.status >= 400) {
-      throw new Error(response.data.message);
+      const tempDiv = document.createElement('div');
+      tempDiv.innerHTML = response.data.message;
+
+      const errorMessage = tempDiv.innerText || tempDiv.textContent;
+      throw new Error(errorMessage);
     }
 
     response

--- a/themes/harmony/assets/express-checkout.js
+++ b/themes/harmony/assets/express-checkout.js
@@ -14,6 +14,10 @@ async function placeOrder() {
 
     const response = await youcanjs.checkout.placeExpressCheckoutOrder({ productVariantId, quantity, fields });
 
+    if (response.data.status >= 400) {
+      throw new Error(response.data.message);
+    }
+
     response
       .onSuccess((data, redirectToThankyouPage) => {
         redirectToThankyouPage();

--- a/themes/meraki/assets/express-checkout.js
+++ b/themes/meraki/assets/express-checkout.js
@@ -15,6 +15,10 @@ async function placeOrder() {
 
     const response = await youcanjs.checkout.placeExpressCheckoutOrder({ productVariantId, quantity, fields });
 
+    if (response.data.status >= 400) {
+      throw new Error(response.data.message);
+    }
+
     response
       .onSuccess((data, redirectToThankyouPage) => {
         redirectToThankyouPage();

--- a/themes/meraki/assets/express-checkout.js
+++ b/themes/meraki/assets/express-checkout.js
@@ -16,7 +16,11 @@ async function placeOrder() {
     const response = await youcanjs.checkout.placeExpressCheckoutOrder({ productVariantId, quantity, fields });
 
     if (response.data.status >= 400) {
-      throw new Error(response.data.message);
+      const tempDiv = document.createElement('div');
+      tempDiv.innerHTML = response.data.message;
+
+      const errorMessage = tempDiv.innerText || tempDiv.textContent;
+      throw new Error(errorMessage);
     }
 
     response


### PR DESCRIPTION
## JIRA Ticket

Ticket: [TH_186](https://youcanshop.atlassian.net/browse/TH_186).

## Prerequisites

* [ ] Check this branch locally and run `pnpm run release`
* [ ] 3 new files will be generated in this format `theme name + date + .zip`
* [ ] Upload generated file locally or in seller-area test env

## QA Steps

* [ ] In seller-area > Settings > General >  Max checkout amount | Max checkout quantity
* [ ] Try to put low values
* [ ] Now go to product page and use the express checkout method to buy the product and make sure that choose high values than max checkout amount or max checkout quantity
* [ ] Normally you will see a popup error show the detail of that error

## Note

- Please make sure to upload theme on you Prod account in seller area and do not use dev mode because it will not gonna work.
- I have also faced this issue (we got the backend content mixed with some HTML) I did a temporary fix until we find out how to solve it.
<img width="1096" alt="Screenshot 2024-10-24 at 16 03 25" src="https://github.com/user-attachments/assets/609a3889-60e6-40eb-84b2-2887179fa097">


