### PR TITLE
Dark: Origins > yc-icon > replace "w" & "h" params by "size"

### DIFF
--- a/themes/origins/sections/default.liquid
+++ b/themes/origins/sections/default.liquid
@@ -3,7 +3,6 @@
   TODO: This section is just a placeholder for the theme pages, as the template schema requires at least one section
 {% endcomment %}
 <div class="default" style="height: 700px;">
-
   <section
     class="section-core"
     style="--space-top: 100px; --space-bottom: 100px;"
@@ -27,7 +26,7 @@
   </section>
 
   <div class="icons-list" style="display: grid; grid-template-columns: repeat(7, 40px); grid-gap: 20px">
-    {% render 'yc-icon', name: 'search', width: '24px', height: '24px' %}
+    {% render 'yc-icon', name: 'search', size: '24px' %}
     {% render 'yc-icon', name: 'cart' %}
     {% render 'yc-icon', name: 'arrow-up' %}
     {% render 'yc-icon', name: 'arrow-down' %}

--- a/themes/origins/snippets/yc-icon.liquid
+++ b/themes/origins/snippets/yc-icon.liquid
@@ -5,8 +5,8 @@
   viewBox="0 0 24 24"
   stroke-width="1.5"
   stroke="currentColor"
-  height="{{ height | default: '18' }}"
-  width="{{ width | default: '18' }}"
+  height="{{ size | default: '18' }}"
+  width="{{ size | default: '18' }}"
 >
   {% if name == 'search' %}
     <path


### PR DESCRIPTION
## JIRA Ticket

Ticket: [TH_X](https://youcanshop.atlassian.net/browse/TH_X).

## Prerequisites

* [ ] Check this branch locally and run `pnpm run release`
* [ ] 3 new files will be generated in this format `theme name + date + .zip`
* [ ] Upload generated file locally or in seller-area test env

## QA Steps

* [ ] Go to `{your_store_slug}.youcan.shop/`

> [!NOTE]
> Why this change? Normally, the `width` and `height` are identical when changing the icon size, so we can simplify it with just one `size` parameter. Btw, we do same thing in [Do3bol](https://github.com/ibrilBadreddine/do3bol-theme/blob/main/src/views/components/sections/slider/index.tsx#L89).

## Note

Leave empty when you have nothing to say.
