### PR TITLE
DARK: Origins > Fix pagination and sort url construction 

### DIFF
--- a/.prettierrc
+++ b/.prettierrc
@@ -1,4 +1,5 @@
 {
   "tabWidth": 2,
-  "useTabs": false
+  "useTabs": false,
+  "printWidth": 80
 }

--- a/.prettierrc
+++ b/.prettierrc
@@ -1,5 +1,5 @@
 {
   "tabWidth": 2,
   "useTabs": false,
-  "printWidth": 80
+  "printWidth": 100
 }

--- a/themes/origins/sections/search.liquid
+++ b/themes/origins/sections/search.liquid
@@ -16,7 +16,7 @@
     --items-columns: {{ section.settings.product_columns }};
   "
 >
-  {%- paginate search.products by 24 cod %}
+  {%- paginate search.products by 1 cod %}
     <div class="product-listing">
       <div class="filter-area">
         <h1 class="title h3">
@@ -59,11 +59,7 @@
             {% assign title = 'single-collection.empty.title' | t %}
             {% assign description = 'single-collection.empty.description' | t %}
 
-            {% render 'yc-empty',
-              icon: 'products',
-              heading: title,
-              subheading: description
-            %}
+            {% render 'yc-empty', icon: 'products', heading: title, subheading: description %}
           </div>
         {% endif %}
       </div>

--- a/themes/origins/sections/search.liquid
+++ b/themes/origins/sections/search.liquid
@@ -16,7 +16,7 @@
     --items-columns: {{ section.settings.product_columns }};
   "
 >
-  {%- paginate search.products by 1 cod %}
+  {%- paginate search.products by 24 cod %}
     <div class="product-listing">
       <div class="filter-area">
         <h1 class="title h3">

--- a/themes/origins/sections/search.liquid
+++ b/themes/origins/sections/search.liquid
@@ -33,9 +33,7 @@
         </h1>
         {% if items.size > 0 %}
           <div class="sort-box">
-            <span class="label">
-              {{ 'general.sort.label' | t }}:
-            </span>
+            <span class="label"> {{ 'general.sort.label' | t }}: </span>
             {% render 'yc-sort', url: previous_page %}
           </div>
         {% endif %}
@@ -61,7 +59,11 @@
             {% assign title = 'single-collection.empty.title' | t %}
             {% assign description = 'single-collection.empty.description' | t %}
 
-            {% render 'yc-empty', icon: 'products', heading: title, subheading: description %}
+            {% render 'yc-empty',
+              icon: 'products',
+              heading: title,
+              subheading: description
+            %}
           </div>
         {% endif %}
       </div>

--- a/themes/origins/sections/single-collection.liquid
+++ b/themes/origins/sections/single-collection.liquid
@@ -22,14 +22,17 @@
   {% endcapture %}
   {% render 'breadcrumb', nav_links_string: nav_links_string %}
 
-  {%- paginate collection.products by 24 cod, category_id: category.id %}
+  {%- paginate collection.products by 1 cod, category_id: category.id %}
     <div class="product-listing">
       {% if subCategories.size > 0 %}
         <div class="collections-area">
           <ul class="items-grid">
             {% for collection in subCategories %}
               <li>
-                {%- render 'collection-card', collection: collection, height: 200 -%}
+                {%- render 'collection-card',
+                  collection: collection,
+                  height: 200
+                -%}
               </li>
             {% endfor %}
           </ul>
@@ -41,9 +44,7 @@
           <span class="h6" data-count>[{{ total }}]</span>
         </h1>
         <div class="sort-box">
-          <span class="label">
-            {{ 'general.sort.label' | t }}:
-          </span>
+          <span class="label"> {{ 'general.sort.label' | t }}: </span>
           {% render 'yc-sort', url: previous_page %}
         </div>
       </div>
@@ -60,14 +61,19 @@
             next_page_url: next_page,
             previous_page_url: previous_page,
             current: current,
-            last: last
+            last: last,
+            base: category.slug
           %}
         {% else %}
           <div class="empty-page">
             {% assign title = 'single-collection.empty.title' | t %}
             {% assign description = 'single-collection.empty.description' | t %}
 
-            {% render 'yc-empty', icon: 'products', heading: title, subheading: description %}
+            {% render 'yc-empty',
+              icon: 'products',
+              heading: title,
+              subheading: description
+            %}
           </div>
         {% endif %}
       </div>

--- a/themes/origins/sections/single-collection.liquid
+++ b/themes/origins/sections/single-collection.liquid
@@ -22,17 +22,14 @@
   {% endcapture %}
   {% render 'breadcrumb', nav_links_string: nav_links_string %}
 
-  {%- paginate collection.products by 24 cod, category_id: category.id %}
+  {%- paginate collection.products by 1 cod, category_id: category.id %}
     <div class="product-listing">
       {% if subCategories.size > 0 %}
         <div class="collections-area">
           <ul class="items-grid">
             {% for collection in subCategories %}
               <li>
-                {%- render 'collection-card',
-                  collection: collection,
-                  height: 200
-                -%}
+                {%- render 'collection-card', collection: collection, height: 200 -%}
               </li>
             {% endfor %}
           </ul>
@@ -69,11 +66,7 @@
             {% assign title = 'single-collection.empty.title' | t %}
             {% assign description = 'single-collection.empty.description' | t %}
 
-            {% render 'yc-empty',
-              icon: 'products',
-              heading: title,
-              subheading: description
-            %}
+            {% render 'yc-empty', icon: 'products', heading: title, subheading: description %}
           </div>
         {% endif %}
       </div>

--- a/themes/origins/sections/single-collection.liquid
+++ b/themes/origins/sections/single-collection.liquid
@@ -22,7 +22,7 @@
   {% endcapture %}
   {% render 'breadcrumb', nav_links_string: nav_links_string %}
 
-  {%- paginate collection.products by 1 cod, category_id: category.id %}
+  {%- paginate collection.products by 24 cod, category_id: category.id %}
     <div class="product-listing">
       {% if subCategories.size > 0 %}
         <div class="collections-area">

--- a/themes/origins/snippets/yc-pagination.liquid
+++ b/themes/origins/snippets/yc-pagination.liquid
@@ -15,16 +15,31 @@
 {% assign start = current | minus: 2 %}
 {% assign end = current | plus: 2 %}
 
-{% assign page_params = '/search?' %}
+{% if base != '' or base != null %}
+  {% assign page_params = '/collections/' | append: base | append: '?' %}
+{% else %}
+  {% assign page_params = '/search?' %}
+{% endif %}
 
 {% if sort_order and sort_field %}
   {%- comment -%}prettier-ignore{%- endcomment -%}
-  {% assign page_params = page_params | append: 'sort_field=' | append: sort_field %}
-  {% assign page_params = page_params | append: '&sort_order=' | append: sort_order | append: '&' %}
+  {% assign page_params = page_params
+    | append: 'sort_field='
+    | append: sort_field
+  %}
+  {% assign page_params = page_params
+    | append: '&sort_order='
+    | append: sort_order
+    | append: '&'
+  %}
 {% endif %}
 
 {% unless terms == null or terms == '' %}
-  {% assign page_params = page_params | append: 'q=' | append: terms | append: '&' %}
+  {% assign page_params = page_params
+    | append: 'q='
+    | append: terms
+    | append: '&'
+  %}
 {% endunless %}
 {% assign page_params = page_params | append: 'page%5Bcod%5D=%p' %}
 

--- a/themes/origins/snippets/yc-pagination.liquid
+++ b/themes/origins/snippets/yc-pagination.liquid
@@ -16,6 +16,13 @@
 {% assign end = current | plus: 2 %}
 
 {% assign page_params = '/search?' %}
+
+{% if sort_order and sort_field %}
+  {%- comment -%}prettier-ignore{%- endcomment -%}
+  {% assign page_params = page_params | append: 'sort_field=' | append: sort_field %}
+  {% assign page_params = page_params | append: '&sort_order=' | append: sort_order | append: '&' %}
+{% endif %}
+
 {% unless terms == null or terms == '' %}
   {% assign page_params = page_params | append: 'q=' | append: terms | append: '&' %}
 {% endunless %}

--- a/themes/origins/snippets/yc-pagination.liquid
+++ b/themes/origins/snippets/yc-pagination.liquid
@@ -22,24 +22,12 @@
 {% endif %}
 
 {% if sort_order and sort_field %}
-  {%- comment -%}prettier-ignore{%- endcomment -%}
-  {% assign page_params = page_params
-    | append: 'sort_field='
-    | append: sort_field
-  %}
-  {% assign page_params = page_params
-    | append: '&sort_order='
-    | append: sort_order
-    | append: '&'
-  %}
+  {% assign page_params = page_params | append: 'sort_field=' | append: sort_field %}
+  {% assign page_params = page_params | append: '&sort_order=' | append: sort_order | append: '&' %}
 {% endif %}
 
 {% unless terms == null or terms == '' %}
-  {% assign page_params = page_params
-    | append: 'q='
-    | append: terms
-    | append: '&'
-  %}
+  {% assign page_params = page_params | append: 'q=' | append: terms | append: '&' %}
 {% endunless %}
 {% assign page_params = page_params | append: 'page%5Bcod%5D=%p' %}
 


### PR DESCRIPTION
## JIRA Ticket

Dark

> [!IMPORTANT]
> I've also increased prettier's printWidth to 100, that's because wrapping liquid `assign` tags cause them to not work
> for example:
> This would not work
>	```
>	{% 
>    assign page_params = page_params 
>      | append: 'q=' 
>      | append: terms 
>      | append: '&' 
>    %}
> ```
> But this will
> ```
> {% assign page_params = page_params | append: 'q=' | append: terms | append: '&' %}
> ```

## Prerequisites

* [ ] Check this branch locally and run `pnpm run release`
* [ ] 3 new files will be generated in this format `theme name + date + .zip`
* [ ] Upload generated file locally or in seller-area test env

## QA Steps

* [ ] Go to a collection page
* [ ] Set the per_page to 1 in code https://github.com/youcan-shop/youcan-themes/blob/b13eb2934317ff2f6e1cefc1d8b7a6bbe12da6a7/themes/origins/sections/single-collection.liquid#L25
* [ ] Go to the collection page in storefront
* [ ] Change the sort order
* [ ] Now paginate through the product, the sort order should be consistent


## Note

Leave empty when you have nothing to say.
