### PR TITLE
Dark: Fix thank you page total

### DIFF
--- a/themes/origins/sections/thank-you.liquid
+++ b/themes/origins/sections/thank-you.liquid
@@ -71,7 +71,7 @@
     <div class="grand-total">
       <div class="summary-item">
         <span class="label">{{ 'order.total' | t }}</span>
-        <span class="value">{{ 0 | money }}</span>
+        <span class="value">{{ order.total | default: 0 | money }}</span>
       </div>
       <a href="/" class="yc-btn">{{ 'order.action' | t }}</a>
     </div>

--- a/themes/origins/templates/index.json
+++ b/themes/origins/templates/index.json
@@ -26,9 +26,6 @@
     },
     "featured-product": {
       "type": "featured-product"
-    },
-    "thank-you": {
-      "type": "thank-you"
     }
   },
   "order": [
@@ -40,7 +37,6 @@
     "products",
     "product-testimonials",
     "custom-content",
-    "featured-product",
-    "thank-you"
+    "featured-product"
   ]
 }


### PR DESCRIPTION
## JIRA Ticket

Darkness

## QA Steps

* [ ] make sure Origins is active
* [ ] Place an order
* [ ] At the end you should get a thank you page and the total price should not be 0 but rather the actual total

![screencapture-slick-dev-youcan-store-checkout-thankyou-2025-02-19-15_16_04](https://github.com/user-attachments/assets/bb0ec384-5073-4a9f-962d-248ccdad15f0)



## Note

Leave empty when you have nothing to say.
