### PR TITLE
TH-351: All themes > store logo is stretched when visiting from a mobile device

### DIFF
--- a/themes/aura/assets/navbar.css
+++ b/themes/aura/assets/navbar.css
@@ -87,6 +87,8 @@
   width:100%;
   max-width:110px;
   max-height:70px;
+  -o-object-fit:contain;
+     object-fit:contain;
 }
 @media (min-width: 768px){
   .yc-header .yc-navbar .logo img{
@@ -203,6 +205,8 @@
   max-width:100%;
   width:-moz-fit-content;
   width:fit-content;
+  -o-object-fit:contain;
+     object-fit:contain;
 }
 .navigation-drawer .items{
   padding:20px 16px;

--- a/themes/aura/styles/navbar.scss
+++ b/themes/aura/styles/navbar.scss
@@ -101,6 +101,7 @@
       width: 100%;
       max-width: 110px;
       max-height: 70px;
+      object-fit: contain;
 
       @include breakpoint('md') {
         max-width: 120px;
@@ -235,6 +236,7 @@
         max-height: 40px;
         max-width: 100%;
         width: fit-content;
+        object-fit: contain;
       }
     }
   }

--- a/themes/harmony/assets/navbar.css
+++ b/themes/harmony/assets/navbar.css
@@ -100,6 +100,8 @@
   width:100%;
   max-width:110px;
   max-height:70px;
+  -o-object-fit:contain;
+     object-fit:contain;
 }
 @media (min-width: 768px){
   .yc-header .yc-navbar .logo img{
@@ -246,6 +248,8 @@
   max-width:100%;
   width:-moz-fit-content;
   width:fit-content;
+  -o-object-fit:contain;
+     object-fit:contain;
 }
 .navigation-drawer .items{
   padding:20px 16px;

--- a/themes/harmony/styles/navbar.scss
+++ b/themes/harmony/styles/navbar.scss
@@ -116,6 +116,7 @@
       width: 100%;
       max-width: 110px;
       max-height: 70px;
+      object-fit: contain;
 
       @include breakpoint('md') {
         max-width: 120px;
@@ -287,6 +288,7 @@
         max-height: 40px;
         max-width: 100%;
         width: fit-content;
+        object-fit: contain;
       }
     }
   }

--- a/themes/meraki/assets/navbar.css
+++ b/themes/meraki/assets/navbar.css
@@ -90,6 +90,8 @@
   width:100%;
   max-width:110px;
   max-height:65px;
+  -o-object-fit:contain;
+     object-fit:contain;
 }
 @media (min-width: 768px){
   .yc-header .yc-navbar .logo img{

--- a/themes/meraki/styles/navbar.scss
+++ b/themes/meraki/styles/navbar.scss
@@ -108,6 +108,7 @@
         width: 100%;
         max-width: 110px;
         max-height: 65px;
+        object-fit: contain;
 
         @include breakpoint('md') {
           max-width: 120px;


### PR DESCRIPTION
## JIRA Ticket

Ticket: [TH-351](https://youcanshop.atlassian.net/browse/TH-351).

## Prerequisites

* [ ] Check this branch locally and run `pnpm run release`
* [ ] 3 new files will be generated in this format `theme name + date + .zip`
* [ ] Upload generated file locally or in seller-area test env

## QA Steps

* [ ] Put this [image](https://shop-themes-assets.ycdn.store/store-images/d049155d-ece7-4f62-9735-1eeea796eeec/logo%20site-2se0ZLlBiarDBSkGrAi6VMAf2D2.png) as logo for your store 
* [ ] Now check your store on Safari Browser

## Note

Leave empty when you have nothing to say.


[TH-351]: https://youcanshop.atlassian.net/browse/TH-351?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ