### PR TITLE
Dark: Origins > Set background  color for default favicon svg

### DIFF
--- a/themes/origins/snippets/head-config.liquid
+++ b/themes/origins/snippets/head-config.liquid
@@ -5,7 +5,7 @@
   rel="stylesheet"
 >
 {% assign slug_initial = store.slug | slice: 0, 1 %}
-{% assign favicon = "data:image/svg+xml, <svg xmlns='http://www.w3.org/2000/svg' width='48' height='48'><text x='50%' y='50%' font-size='48' fill='white' text-anchor='middle' dominant-baseline='middle'>[SLUG]</text></svg>" %}
+{% assign favicon = "data:image/svg+xml, <svg xmlns='http://www.w3.org/2000/svg' width='48' height='48' viewBox='0 0 48 48'><rect width='100%' height='100%' fill='white' rx='8' ry='8'/><text x='50%' y='50%' font-size='48' fill='currentColor' text-anchor='middle' dy='10'>[SLUG]</text></svg>" %}
 {% assign favicon = favicon | replace: '[SLUG]', slug_initial %}
 
 {% if settings.favicon.src %}


### PR DESCRIPTION
## JIRA Ticket

Ticket: [TH_X](https://youcanshop.atlassian.net/browse/TH_X).

## Prerequisites

* [ ] Check this branch locally and run `pnpm run release`
* [ ] 3 new files will be generated in this format `theme name + date + .zip`
* [ ] Upload generated file locally or in seller-area test env

## QA Steps

* [ ] Go to `{your_store_slug}`.youcan.shop/*
* [ ] Make sure the default favicon includes a background color

| Before | After |
|--------|--------|
| <img width="300" alt="Screenshot 2025-03-07 at 10 45 38" src="https://github.com/user-attachments/assets/7442b5bf-1391-444a-a884-8a7ad75cc3f3" /> | <img width="300" alt="Screenshot 2025-03-07 at 10 45 25" src="https://github.com/user-attachments/assets/e9687abc-9c84-4350-9dca-4503bf7adf2a" /> | 

## Note

Leave empty when you have nothing to say.
