### PR TITLE
DARK: Origins > Fix page width break on mobile

### DIFF
--- a/themes/origins/assets/product-card.css
+++ b/themes/origins/assets/product-card.css
@@ -62,8 +62,8 @@
   justify-self:var(--product-card-text-alignment);
 }
 .product-card .info .title{
-  width:-moz-fit-content;
-  width:fit-content;
+  width:min(-moz-fit-content, 100%);
+  width:min(fit-content, 100%);
   max-width:100%;
   white-space:nowrap;
   overflow:hidden;

--- a/themes/origins/snippets/product-description.liquid
+++ b/themes/origins/snippets/product-description.liquid
@@ -8,6 +8,8 @@
   {% render 'product-description', description: 'Product description (Rich content)' %}
 {% endcomment %}
 
-<div class="description">
-  {{ description }}
-</div>
+{% if description %}
+  <div class="description">
+    {{ description }}
+  </div>
+{% endif %}

--- a/themes/origins/snippets/product-description.liquid
+++ b/themes/origins/snippets/product-description.liquid
@@ -9,5 +9,5 @@
 {% endcomment %}
 
 <div class="description">
-  {{ description | default: 'Description' }}
+  {{ description }}
 </div>

--- a/themes/origins/styles/product-card.scss
+++ b/themes/origins/styles/product-card.scss
@@ -80,7 +80,7 @@
     }
 
     .title {
-      width: fit-content;
+      width: min(fit-content, 100%);
       max-width: 100%;
       white-space: nowrap;
       overflow: hidden;


### PR DESCRIPTION
## JIRA Ticket

Ticket: [TH_X](https://youcanshop.atlassian.net/browse/TH_X).

## Prerequisites

* [ ] Check this branch locally and run `pnpm run release`
* [ ] 3 new files will be generated in this format `theme name + date + .zip`
* [ ] Upload generated file locally or in seller-area test env

## QA Steps

* [ ] Open storefront in Safari (or Chrome on iOS)
* [ ] Make sure you have a products section in your homepage
* [ ] The product card width should be 100% of the available width of the screen (Previously the card was bleeding off the edge)


## Note

Leave empty when you have nothing to say.
