### PR TITLE
TH-408: Origins > Countown timer minute and second not calc'ed

### DIFF
--- a/themes/origins/sections/featured-product.liquid
+++ b/themes/origins/sections/featured-product.liquid
@@ -133,8 +133,8 @@
               month: block.settings.month,
               day: block.settings.day,
               hour: block.settings.hour,
-              minute: block.settings.minutes,
-              second: block.settings.seconds,
+              minute: block.settings.minute,
+              second: block.settings.second,
               title: block.settings.title
             %}
           {% when 'accordion' %}

--- a/themes/origins/sections/single-product.liquid
+++ b/themes/origins/sections/single-product.liquid
@@ -132,8 +132,8 @@
               month: block.settings.month,
               day: block.settings.day,
               hour: block.settings.hour,
-              minute: block.settings.minutes,
-              second: block.settings.seconds,
+              minute: block.settings.minute,
+              second: block.settings.second,
               title: block.settings.title
             %}
           {% when 'accordion' %}


### PR DESCRIPTION
## JIRA Ticket

Ticket: [TH-408](https://youcanshop.atlassian.net/browse/TH-408).

## Prerequisites

* [ ] Check this branch locally and run `pnpm run release`
* [ ] 3 new files will be generated in this format `theme name + date + .zip`
* [ ] Upload generated file locally or in seller-area test env

## QA Steps
### Homepage
* [ ] Go to theme editor
* [ ] Add a featured product section to the home
* [ ] Add a countdown timer block
* [ ] Set the end time to 1 hour and 59 minutes from your current time
* [ ] You should see that the countdown has 1hr 59m remaining

### Product page
* [ ] Go to theme editor
* [ ] Add a countdown timer block
* [ ] Set the end time to 1 hour and 59 minutes from your current time
* [ ] You should see that the countdown has 1hr 59m remaining

## Note

Leave empty when you have nothing to say.


[TH-408]: https://youcanshop.atlassian.net/browse/TH-408?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ