### PR TITLE
TH-413: Origins > Product Card > Show "Shop now" if skip cart is enabled

### DIFF
--- a/themes/origins/assets/cart.js
+++ b/themes/origins/assets/cart.js
@@ -237,14 +237,14 @@ class CartDrawerItems extends BaseCartItem {
     const { sub_total } = payload.cartData;
 
     if (payload.source === "product-form") {
-      this.cart.open();
+      payload.skipCart ? (window.location.href = "/cart") : this.cart.open();
     }
 
     if (payload.source === "quick-view") {
       const quickViewModal = document.querySelector("yc-product yc-modal:has(yc-modal-content[data-visible])");
 
       quickViewModal.close();
-      this.cart.open();
+      payload.skipCart ? (window.location.href = "/cart") : this.cart.open();
     }
 
     this.updateCartSubTotal(sub_total);

--- a/themes/origins/assets/cart.js
+++ b/themes/origins/assets/cart.js
@@ -281,10 +281,6 @@ class CartItems extends BaseCartItem {
     this.cart = this.closest("[data-cart]");
   }
 
-  handleCartUpdate(payload) {
-    if (payload.source === "product-form") this.cart.open();
-  }
-
   getCartItemTemplate() {
     return this.cart.querySelector("[data-cart-item-template]");
   }

--- a/themes/origins/assets/component-product-form.js
+++ b/themes/origins/assets/component-product-form.js
@@ -1,6 +1,6 @@
 if (!customElements.get("yc-product-form")) {
   class ProductForm extends HTMLElement {
-    static observedAttributes = ["variant-id", "quantity", "checkout-type", "attached-image", "source", "not-available"];
+    static observedAttributes = ["variant-id", "quantity", "checkout-type", "attached-image", "source", "not-available", "skip-cart"];
 
     constructor() {
       super();
@@ -67,6 +67,7 @@ if (!customElements.get("yc-product-form")) {
 
         publish(PUB_SUB_EVENTS.cartUpdate, {
           source: this.getAttribute("source") ?? "product-form",
+          skipCart: this.hasAttribute("skip-cart"),
           productVariantId,
           cartData: newCart,
         });

--- a/themes/origins/locales/ar.json
+++ b/themes/origins/locales/ar.json
@@ -2,6 +2,7 @@
   "general": {
     "all": "الكل",
     "buy_now": "اشتري الآن",
+    "shop_now": "تسوّق الآن",
     "add_to_cart": "أضف إلى السلة",
     "out_of_stock": "نفذ من المخزون",
     "show_all_button": "عرض الكل",

--- a/themes/origins/locales/en.default.json
+++ b/themes/origins/locales/en.default.json
@@ -2,6 +2,7 @@
   "general": {
     "all": "All",
     "buy_now": "Buy now",
+    "shop_now": "Shop now",
     "add_to_cart": "Add to cart",
     "out_of_stock": "Out of stock",
     "show_all_button": "View all",

--- a/themes/origins/locales/fr.json
+++ b/themes/origins/locales/fr.json
@@ -1,7 +1,8 @@
 {
   "general": {
     "all": "Tous",
-    "buy_now": "Acheter",
+    "buy_now": "Acheter maintenant",
+    "shop_now": "Commander maintenant",
     "add_to_cart": "Ajouter au panier",
     "out_of_stock": "En rupture de stock",
     "show_all_button": "Voir tout",

--- a/themes/origins/snippets/product-add-to-cart.liquid
+++ b/themes/origins/snippets/product-add-to-cart.liquid
@@ -4,6 +4,7 @@
   Accepts:
   - variant_id: {String}  Default variant id
   - available: {Boolean} Whether the variant is available or not
+  - skip_cart: {Boolean} (Optional) Skips the cart drawer and takes users to the cart page (after adding an item)
 
   Usage:
   {% render 'product-add-to-cart', variant_id: '045-dj8-30k-ws7', available: true %}
@@ -18,6 +19,9 @@
   {% if source %}
     source="{{ source }}"
   {% endif %}
+  {% if skip_cart %}
+    skip-cart
+  {% endif %}
 >
   <button
     name="add"
@@ -28,7 +32,7 @@
     {% endunless %}
   >
     <span
-      data-add-to-cart="{{ 'general.add_to_cart' | t }}"
+      data-add-to-cart="{% if skip_cart %}{{ 'general.shop_now' | t }}{% else %}{{ 'general.add_to_cart' | t }}{% endif %}"
       data-out-of-stock="{{ 'general.out_of_stock' | t }}"
     >
     </span>

--- a/themes/origins/snippets/product-buy-button.liquid
+++ b/themes/origins/snippets/product-buy-button.liquid
@@ -14,6 +14,6 @@
   {% if settings.checkout_type == 'express' %}
     {% render 'yc-express-checkout', variant_id: default_variant.id, available: product.available, is_sticky: is_sticky %}
   {% else %}
-    {% render 'yc-add-to-cart', variant_id: default_variant.id, available: product.available %}
+    {% render 'yc-add-to-cart', variant_id: default_variant.id, available: product.available, skip_cart: product.skip_to_checkout %}
   {% endif %}
 </div>

--- a/themes/origins/snippets/product-card.liquid
+++ b/themes/origins/snippets/product-card.liquid
@@ -61,7 +61,7 @@
         {% if product.variants.size > 1 %}
           {% render 'product-quick-view', product: product %}
         {% else %}
-          {% render 'product-add-to-cart', variant_id: default_variant.id, available: product.available %}
+          {% render 'product-add-to-cart', variant_id: default_variant.id, available: product.available, skip_cart: product.skip_to_checkout %}
         {% endif %}
       {% endif %}
     {% endunless %}

--- a/themes/origins/snippets/product-quick-view.liquid
+++ b/themes/origins/snippets/product-quick-view.liquid
@@ -66,7 +66,12 @@
               </div>
               {% render 'product-variants' %}
             </div>
-            {% render 'yc-add-to-cart', variant_id: default_variant.id, available: default_variant.available, source: 'quick-view' %}
+            {% render 'yc-add-to-cart',
+              variant_id: default_variant.id,
+              available: default_variant.available,
+              skip_cart: product.skip_to_checkout,
+              source: 'quick-view'
+            %}
           </yc-product-info>
         </div>
       </div>

--- a/themes/origins/snippets/yc-add-to-cart.liquid
+++ b/themes/origins/snippets/yc-add-to-cart.liquid
@@ -5,6 +5,7 @@
   - variant_id: {String} Default variant id
   - available: {Boolean} Whether the variant is available or not
   - source: {String} (Optional) Parent source 'product-form', 'quick-view'
+  - skip_cart: {Boolean} (Optional) Skips the cart drawer and takes users to the cart page (after adding an item)
 
   Usage:
   {% render 'yc-add-to-cart', variant_id: '045-dj8-30k-ws7', available: true %}
@@ -21,6 +22,9 @@
   {% if source %}
     source="{{ source }}"
   {% endif %}
+  {% if skip_cart %}
+    skip-cart
+  {% endif %}
 >
   {% render 'yc-quantity-control', product: product, inventory: product.selected_or_first_available_variant.inventory %}
   <button
@@ -32,7 +36,7 @@
     {% endunless %}
   >
     <span
-      data-add-to-cart="{{ 'general.add_to_cart' | t }}"
+      data-add-to-cart="{% if skip_cart %}{{ 'general.shop_now' | t }}{% else %}{{ 'general.add_to_cart' | t }}{% endif %}"
       data-out-of-stock="{{ 'general.out_of_stock' | t }}"
     >
     </span>

--- a/themes/origins/snippets/yc-express-checkout.liquid
+++ b/themes/origins/snippets/yc-express-checkout.liquid
@@ -1,3 +1,11 @@
+{% for field in checkout.fields %}
+  {% if field.type == 'select' %}
+    {{ 'component-combobox.css' | asset_url | stylesheet_tag }}
+    {{ 'component-combobox.js' | asset_url | script_tag_deferred }}
+    {% break %}
+  {% endif %}
+{% endfor %}
+
 {% comment %}
   Renders a checkout form (usually used in featured & single product sections)
 


### PR DESCRIPTION
## JIRA Ticket

Ticket: [TH-413](https://youcanshop.atlassian.net/browse/TH-413).

## Prerequisites

* [ ] Check this branch locally and run `pnpm run release`
* [ ] 3 new files will be generated in this format `theme name + date + .zip`
* [ ] Upload generated file locally or in seller-area test env

## QA Steps

#### Test 1

> [!NOTE]
> Ensure your store's checkout type is set to "Normal"

* [ ] Seller area -> Store -> Theme ->  [Product settings (advanced)
](https://seller-area.youcan.shop/admin/theme#product)
* [ ] Try to enable `Skip cart` option
* [ ] Check your store to see if the product card actions are now "Shop now" instead of "Add to cart"
* [ ] The same thing should happen on the product details page
* [ ] **`Preview:`**

| Disabled | Enabled |
|--------|--------|
| <img width="150" alt="Screenshot 2025-03-24 at 13 04 02" src="https://github.com/user-attachments/assets/d977b5e4-9943-43b4-9ff2-95da4a4f309d" /> | <img width="150" alt="Screenshot 2025-03-24 at 13 03 29" src="https://github.com/user-attachments/assets/0fd767dc-e284-4710-9b5b-050298451f46" /> | 


#### Test 2

> [!NOTE]
> Make sure the [global](https://seller-area.youcan.shop/admin/theme#product) "Skip cart" feature is turned off

* [ ] Seller area -> All products -> Pick a product ->  Advanced options
* [ ] Try to enable `Skip cart` option
* [ ] Check your store to see if your product card action is now "Shop now" instead of "Add to cart"

> Verify that the change affects only the product you’ve chosen



## Note

Leave empty when you have nothing to say.


[TH-413]: https://youcanshop.atlassian.net/browse/TH-413?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ