### PR TITLE
TH-377: Origins > Upsell pages don't stack up when there are more than one upsell with different weights

### DIFF
--- a/themes/origins/assets/component-upsell.js
+++ b/themes/origins/assets/component-upsell.js
@@ -14,6 +14,9 @@ class Upsell extends HTMLElement {
   }
 
   async handleChoice(event) {
+    event.target.setAttribute("data-loading", true);
+    this.disableActionButtons();
+
     const answer = event.target.name;
 
     if (answer !== "yes" && answer !== "no") return;
@@ -27,11 +30,9 @@ class Upsell extends HTMLElement {
 
     try {
       await youcanjs.upsell.answer(params);
-    } catch (error) {
-      console.error(error);
 
-      toast.show(error.message, "error");
-    } finally {
+      window.location.reload();
+    } catch (error) {
       window.location.href = "/checkout/thankyou";
     }
   }
@@ -51,6 +52,16 @@ class Upsell extends HTMLElement {
       console.error(error);
       return {};
     }
+  }
+
+  disableActionButtons() {
+    const actionButtons = document.querySelectorAll('[data-upsell-submit]');
+
+    if (!actionButtons.length) return;
+
+    actionButtons.forEach(button => {
+      button.disabled = true;
+    });
   }
 }
 

--- a/themes/origins/sections/upsell.liquid
+++ b/themes/origins/sections/upsell.liquid
@@ -4,7 +4,7 @@
 {% capture product_offers %}
 {
   {% for product in upsell.products %}
-    "product_offers[{{ product.id }}]": "{{ product.variants.0.id }}"
+    "{{ product.id }}": "{{ product.variants.0.id }}"
     {% unless forloop.last %},{% endunless %}
   {% endfor %}
 }
@@ -35,21 +35,21 @@
     >
       <span class="title">{{ 'upsell.offer_title' | t }}</span>
       <button
-        data-upsell
+        data-upsell-submit
         name="no"
         class="yc-btn"
         data-button-size="{{ upsell.actions.btn_no.size }}"
         data-font-size="{{ upsell.actions.btn_no.font_size }}"
       >
-        {{ upsell.actions.btn_no.title }}
+        <span>{{ upsell.actions.btn_no.title }}</span>
       </button>
       <button
-        data-upsell
+        data-upsell-submit
         name="yes"
         data-button-size="{{ upsell.actions.btn_yes.size }}"
         data-font-size="{{ upsell.actions.btn_yes.font_size }}"
       >
-        {{- upsell.actions.btn_yes.title -}}
+        <span>{{ upsell.actions.btn_yes.title }}</span>
       </button>
     </yc-upsell>
     <div class="footer">


### PR DESCRIPTION
## JIRA Ticket

Ticket: [TH-377](https://youcanshop.atlassian.net/browse/TH-377).

## Prerequisites

* [ ] Check this branch locally and run `pnpm run release`
* [ ] 3 new files will be generated in this format `theme name + date + .zip`
* [ ] Upload generated file locally or in seller-area test env

## QA Steps

* [ ] Upload the generated origins theme in production
* [ ] Create 3 upsell pages and put the weight by order from 1 to 3


[TH-377]: https://youcanshop.atlassian.net/browse/TH-377?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ