### PR TITLE
fix(bella): theme variant images + rtl issues

### DIFF
--- a/.changeset/curvy-humans-lead.md
+++ b/.changeset/curvy-humans-lead.md
@@ -1,0 +1,5 @@
+---
+"bella": patch
+---
+
+fix > theme variant images + rtl issues

--- a/themes/bella/assets/main.css
+++ b/themes/bella/assets/main.css
@@ -1037,9 +1037,6 @@
   [ui-slot=accordion] [ui-slot=accordion-item] [ui-slot=accordion-trigger]::after{
     transform:rotate(90deg);
   }
-  [dir="rtl"] [ui-slot=accordion] [ui-slot=accordion-item] [ui-slot=accordion-trigger]::before,[dir="rtl"]  [ui-slot=accordion] [ui-slot=accordion-item] [ui-slot=accordion-trigger]::after{
-    inset-inline:0 auto;
-  }
   [ui-slot=accordion] [ui-slot=accordion-item]{
   }
   [ui-slot=accordion] [ui-slot=accordion-item] [ui-slot=accordion-content]{

--- a/themes/bella/assets/main.css
+++ b/themes/bella/assets/main.css
@@ -2373,12 +2373,10 @@
   [ui-slot=breadcrumb]{
     --separator-arrow-rotate:-45deg;
     --separator-splash-rotate:15deg;
-    --separator-arrow-translate:0;
   }
   [dir="rtl"] [ui-slot=breadcrumb]{
-    --separator-arrow-rotate:135deg;
+    --separator-arrow-rotate:45deg;
     --separator-splash-rotate:-15deg;
-    --separator-arrow-translate:-4px;
   }
   [ui-slot=breadcrumb]{
   }
@@ -2421,7 +2419,7 @@
     width:6px;
     height:6px;
     margin-inline-start:0;
-    transform:rotate(var(--separator-arrow-rotate)) translate(var(--separator-arrow-translate), var(--separator-arrow-translate));
+    transform:rotate(var(--separator-arrow-rotate));
     border-block-end:1.2px solid color-mix(in srgb, var(--color-on-surface) 38%, transparent);
   }
   [ui-slot=pagination]{

--- a/themes/bella/assets/section.product.js
+++ b/themes/bella/assets/section.product.js
@@ -9,6 +9,7 @@ if (!customElements.get("ui-product")) {
       super();
 
       this.variants = [...this.querySelectorAll("[ui-variant]")];
+      this.productMedia = this.querySelector('[ui-product="media"]');
       this.productForms = this.querySelectorAll("ui-shop-button");
       this.productVariants = window.productsVariants[this.getAttribute("product-id")];
     }
@@ -96,11 +97,12 @@ if (!customElements.get("ui-product")) {
     updateMainImage(image_src) {
       if (!this.productMedia) return;
 
-      this.productMedia.querySelectorAll("img").forEach((element, i) => {
-        if (element.src === image_src) {
-          // Add your logic
-        }
-      });
+      const images = this.productMedia.querySelectorAll("img");
+      const index = [...images].findIndex((img) => img.src === image_src);
+
+      if (index !== -1) {
+        this.productMedia.swipe(index);
+      }
     }
 
     disableUnavailableOptions() {

--- a/themes/bella/snippets/misc.product-media.liquid
+++ b/themes/bella/snippets/misc.product-media.liquid
@@ -5,7 +5,7 @@
   {% render 'misc.product-media' %}
 {% endcomment %}
 
-<ui-carousel class="media" data-layout="carousel">
+<ui-carousel class="media" data-layout="carousel" ui-product="media">
   {% if product.images.size > 1 %}
     <button
       class="arrow"

--- a/themes/bella/styles/components/disclosure/accordion.scss
+++ b/themes/bella/styles/components/disclosure/accordion.scss
@@ -65,13 +65,6 @@
       &::after {
         transform: rotate(90deg);
       }
-
-      &:dir(rtl) {
-        &::before,
-        &::after {
-          inset-inline: 0 auto;
-        }
-      }
     }
 
     /* Content */

--- a/themes/bella/styles/components/navigation/breadcrumb.scss
+++ b/themes/bella/styles/components/navigation/breadcrumb.scss
@@ -20,12 +20,10 @@
 [ui-slot="breadcrumb"] {
   --separator-arrow-rotate: -45deg;
   --separator-splash-rotate: 15deg;
-  --separator-arrow-translate: 0;
 
   &:dir(rtl) {
-    --separator-arrow-rotate: 135deg;
+    --separator-arrow-rotate: 45deg;
     --separator-splash-rotate: -15deg;
-    --separator-arrow-translate: -4px;
   }
 
   /* Group */
@@ -72,7 +70,7 @@
         width: 6px;
         height: 6px;
         margin-inline-start: 0;
-        transform: rotate(var(--separator-arrow-rotate)) translate(var(--separator-arrow-translate), var(--separator-arrow-translate));
+        transform: rotate(var(--separator-arrow-rotate));
         border-block-end: 1.2px solid color-mix(in srgb, var(--color-on-surface) 38%, transparent);
       }
     }


### PR DESCRIPTION
## Prerequisites

- [ ] Check this branch locally and run `pnpm run release`
- [ ] 3 new files will be generated in this format `theme name + date + .zip`
- [ ] Upload generated file locally or in seller-area test env

## QA Steps

- [ ] Go to your storefront (bella your active theme)
- [ ] Visit a product with variants (at least one variant assigned to an image), Verify if the selected image change when you pick a deferent variant option
- [ ] Also check the breadcrumb + accordion components in both directions (LTR & RTL), should be fine now (arrows)


## Note

Leave empty when you have nothing to say.
