### PR TITLE
fix(bella): single collection > empty > add translation

### DIFF
--- a/.changeset/lovely-horses-care.md
+++ b/.changeset/lovely-horses-care.md
@@ -1,0 +1,5 @@
+---
+"bella": patch
+---
+
+bella > single collection > empty > add translation

--- a/themes/bella/locales/ar.json
+++ b/themes/bella/locales/ar.json
@@ -96,22 +96,20 @@
   },
   "collections": {
     "empty": {
-      "title": "لا توجد مجموعات متاحة",
-      "description": ""
+      "title": "لا توجد مجموعات متاحة"
     }
   },
   "single-collection": {
     "empty": {
-      "title": "لا توجد منتجات متاحة",
-      "description": ""
+      "title": "عذرا ، لا توجد منتجات في هذه المجموعة",
+      "action": "اكتشف مجموعات أخرى"
     }
   },
   "search": {
     "title": "بحث",
     "placeholder": "ابحث عن المنتجات..",
     "empty": {
-      "title": "لا توجد نتيجة بحث",
-      "description": ""
+      "title": "لا توجد نتيجة بحث"
     },
     "drawer": {
       "terms_recommendations": "أكثر المصطلحات بحثاً",
@@ -189,7 +187,7 @@
     "insufficient_inventory": "توجد [inventory] قطعة فقط في المخزون",
     "rating_is_required": "الرجاء تقييم المنتج",
     "large_file": "[file] أكبر من 2 ميجا بايت",
-    "invalid_phone_number":  "يرجى إدخال رقم هاتف صحيح"
+    "invalid_phone_number": "يرجى إدخال رقم هاتف صحيح"
   },
   "header": {
     "menu": {

--- a/themes/bella/locales/en.default.json
+++ b/themes/bella/locales/en.default.json
@@ -96,22 +96,20 @@
   },
   "collections": {
     "empty": {
-      "title": "No collections available",
-      "description": ""
+      "title": "No collections available"
     }
   },
   "single-collection": {
     "empty": {
-      "title": "No products available",
-      "description": ""
+      "title": "Sorry, there are no products in this collection",
+      "action": "Explore Other Collections"
     }
   },
   "search": {
     "title": "Search",
     "placeholder": "Search products..",
     "empty": {
-      "title": "No search result",
-      "description": ""
+      "title": "No search result"
     },
     "drawer": {
       "terms_recommendations": "Most searched terms",

--- a/themes/bella/locales/fr.json
+++ b/themes/bella/locales/fr.json
@@ -96,22 +96,20 @@
   },
   "collections": {
     "empty": {
-      "title": "Aucune collection disponible",
-      "description": ""
+      "title": "Aucune collection disponible"
     }
   },
   "single-collection": {
     "empty": {
-      "title": "Aucune produit disponible",
-      "description": ""
+      "title": "Désolé, il n'y a aucun produit dans cette collection",
+      "action": "Explorez D'Autres Collections"
     }
   },
   "search": {
     "title": "Recherche",
     "placeholder": "Rechercher des produits..",
     "empty": {
-      "title": "Aucun résultat trouvé",
-      "description": ""
+      "title": "Aucun résultat trouvé"
     },
     "drawer": {
       "terms_recommendations": "Termes les plus recherchés",

--- a/themes/bella/sections/single-collection.liquid
+++ b/themes/bella/sections/single-collection.liquid
@@ -76,8 +76,9 @@
         {% render 'misc.pagination', next_page_url: next_page, previous_page_url: previous_page, current: current, last: last, terms: terms %}
 
       {% else %}
-        {% assign empty_content = 'Sorry, there are no products in this collection.' %}
-        {% render 'misc.empty', heading: empty_content, action_label: 'Explore Other Collections', action_url: '/collections' %}
+        {% assign empty_content = 'single-collection.empty.title' | t %}
+        {% assign empty_action = 'single-collection.empty.action' | t %}
+        {% render 'misc.empty', heading: empty_content, action_label: empty_action, action_url: '/collections' %}
       {% endif %}
     </div>
   {% endpaginate %}


### PR DESCRIPTION
## Prerequisites

- [ ] Check this branch locally and run `pnpm run release`
- [ ] 3 new files will be generated in this format `theme name + date + .zip`
- [ ] Upload generated file locally or in seller-area test env

## QA Steps

- [ ] Go to your storefront (Bella your active theme)
- [ ] `/collections/{collection_with_no_products}`, verify if the empty message + button are translated.

## Note

Leave empty when you have nothing to say.
