### PR TITLE
fix: variant image upload (bella/camisa/mono)

### DIFF
--- a/.changeset/clever-plants-fix.md
+++ b/.changeset/clever-plants-fix.md
@@ -1,0 +1,8 @@
+---
+"chameleon": patch
+"camisa": patch
+"bella": patch
+"mono": patch
+---
+
+Fix attached image issue (express checkout)

--- a/.changeset/wet-glasses-sneeze.md
+++ b/.changeset/wet-glasses-sneeze.md
@@ -1,0 +1,7 @@
+---
+"camisa": patch
+"bella": patch
+"mono": patch
+---
+
+Fix variant image upload

--- a/themes/bella/assets/core.shop-button.js
+++ b/themes/bella/assets/core.shop-button.js
@@ -98,7 +98,7 @@ if (!customElements.get("ui-shop-button")) {
 
         const selectedVariant = newCart.items.find((variant) => variant.productVariant.id === productVariantId);
 
-        window.Dotshop.pixels.publish('add-to-cart', selectedVariant);
+        window.Dotshop.pixels.publish("add-to-cart", selectedVariant);
       } catch (error) {
         console.error(error);
 
@@ -121,9 +121,8 @@ if (!customElements.get("ui-shop-button")) {
       try {
         const response = await youcanjs.checkout.placeExpressCheckoutOrder({
           productVariantId,
-          attachedImage,
           quantity,
-          fields,
+          fields: { ...fields, ...(attachedImage && { attachedImage }) },
         });
 
         response

--- a/themes/bella/assets/core.variants.css
+++ b/themes/bella/assets/core.variants.css
@@ -162,4 +162,20 @@
     opacity:0.5;
     pointer-events:none;
   }
+  ui-variants .upload-output{
+    position:relative;
+    width:-moz-fit-content;
+    width:fit-content;
+    height:80px;
+  }
+  ui-variants .upload-output img{
+    -o-object-fit:cover;
+       object-fit:cover;
+    border-radius:max(0px, min(var(--radius-input), var(--radius-16)));
+  }
+  ui-variants .upload-output button{
+    position:absolute;
+    inset-inline-end:calc(var(--spacing-8) * -1);
+    inset-block-end:calc(var(--spacing-8) * -1);
+  }
 }

--- a/themes/bella/assets/core.variants.css
+++ b/themes/bella/assets/core.variants.css
@@ -178,4 +178,7 @@
     inset-inline-end:calc(var(--spacing-8) * -1);
     inset-block-end:calc(var(--spacing-8) * -1);
   }
+  ui-variants .upload-output button:hover{
+    background-color:var(--color-button-container) !important;
+  }
 }

--- a/themes/bella/assets/main.css
+++ b/themes/bella/assets/main.css
@@ -1532,9 +1532,9 @@
     transition:all 500ms cubic-bezier(0.27, 1.06, 0.18, 1);
     transition:all var(--transition-standard-default-spatial);
     border:1px dashed color-mix(in srgb, var(--color-on-surface-variant) 38%, transparent);
-    border-radius:12px;
-    border-radius:var(--radius-12);
-    background-color:var(--color-background);
+    border-radius:max(0px, min(var(--radius-input), 16px));
+    border-radius:max(0px, min(var(--radius-input), var(--radius-16)));
+    background-color:var(--color-surface-container-low);
     cursor:pointer;
     gap:calc(24px - 4px);
     gap:calc(var(--spacing-24) - var(--spacing-4));
@@ -1580,9 +1580,8 @@
     padding-inline:10px;
     padding-inline:var(--spacing-10);
     border:1px solid var(--color-surface-variant);
-    border-radius:8px;
-    border-radius:var(--radius-8);
-    background-color:var(--color-background);
+    border-radius:var(--radius-input);
+    background-color:var(--color-surface-container);
     color:var(--color-on-surface-variant);
   }
   [ui-slot=file-upload]:hover{
@@ -2225,8 +2224,8 @@
     transition:all 500ms cubic-bezier(0.27, 1.06, 0.18, 1);
     transition:all var(--transition-standard-default-spatial);
     border:1px solid transparent;
-    border-radius:8px;
-    border-radius:var(--radius-8);
+    border-radius:max(0px, min(var(--radius-input), 16px));
+    border-radius:max(0px, min(var(--radius-input), var(--radius-16)));
     outline:2px solid transparent;
     outline-offset:1px;
     background-color:var(--color-surface-container-low);

--- a/themes/bella/assets/section.product.js
+++ b/themes/bella/assets/section.product.js
@@ -149,7 +149,12 @@ if (!customElements.get("ui-product")) {
       const fileSizeInKB = file.size / Product.BYTES_IN_KB;
       const fileSizeInMB = fileSizeInKB / Product.KB_IN_MB;
 
-      if (fileSizeInMB > Product.MAXIMUM_FILE_SIZE) return null;
+      if (fileSizeInMB > Product.MAXIMUM_FILE_SIZE) {
+        const message = window.errorStrings.large_file;
+        toast.show(message.replace("[file]", `"${file.name}"`), "error");
+
+        return;
+      }
 
       return fileInput
         ? new Promise((resolve) => {

--- a/themes/bella/snippets/core.variants.liquid
+++ b/themes/bella/snippets/core.variants.liquid
@@ -129,6 +129,20 @@
           </div>
           <div ui-slot="file-upload-button">{{ 'product.upload_image.trigger' | t }}</div>
         </label>
+        <div class="upload-output" hidden>
+          <img src="" alt="" width="80" height="80">
+          <button
+            type="button"
+            ui-slot="button"
+            data-variant="error"
+            data-mode="lighter"
+            data-size="xs"
+            data-as-icon
+            aria-label="remove"
+          >
+            {% render 'misc.icon', name: 'hgi-delete-02' %}
+          </button>
+        </div>
       {% endif %}
     </div>
   {% endfor %}

--- a/themes/bella/styles/components/form/file-upload.scss
+++ b/themes/bella/styles/components/form/file-upload.scss
@@ -22,10 +22,9 @@
   align-items: center;
   padding: var(--spacing-32);
   transition: all var(--transition-standard-default-spatial);
-  border: 1px dashed
-    color-mix(in srgb, var(--color-on-surface-variant) 38%, transparent);
-  border-radius: var(--radius-12);
-  background-color: var(--color-background);
+  border: 1px dashed color-mix(in srgb, var(--color-on-surface-variant) 38%, transparent);
+  border-radius: clamp(0px, var(--radius-input), var(--radius-16));
+  background-color: var(--color-surface-container-low);
   cursor: pointer;
   gap: calc(var(--spacing-24) - var(--spacing-4));
 
@@ -69,8 +68,8 @@
     height: 32px;
     padding-inline: var(--spacing-10);
     border: 1px solid var(--color-surface-variant);
-    border-radius: var(--radius-8);
-    background-color: var(--color-background);
+    border-radius: var(--radius-input);
+    background-color: var(--color-surface-container);
     color: var(--color-on-surface-variant);
   }
 

--- a/themes/bella/styles/components/form/textarea.scss
+++ b/themes/bella/styles/components/form/textarea.scss
@@ -10,7 +10,7 @@
   padding: var(--spacing-10) var(--spacing-12);
   transition: all var(--transition-standard-default-spatial);
   border: 1px solid transparent;
-  border-radius: var(--radius-8);
+  border-radius: clamp(0px, var(--radius-input), var(--radius-16));
   outline: 2px solid transparent;
   outline-offset: 1px;
   background-color: var(--color-surface-container-low);

--- a/themes/bella/styles/core.variants.scss
+++ b/themes/bella/styles/core.variants.scss
@@ -206,5 +206,22 @@
         }
       }
     }
+
+    .upload-output {
+      position: relative;
+      width: fit-content;
+      height: 80px;
+
+      img {
+        object-fit: cover;
+        border-radius: clamp(0px, var(--radius-input), var(--radius-16));
+      }
+
+      button {
+        position: absolute;
+        inset-inline-end: calc(var(--spacing-8) * -1);
+        inset-block-end: calc(var(--spacing-8) * -1);
+      }
+    }
   }
 }

--- a/themes/bella/styles/core.variants.scss
+++ b/themes/bella/styles/core.variants.scss
@@ -221,6 +221,10 @@
         position: absolute;
         inset-inline-end: calc(var(--spacing-8) * -1);
         inset-block-end: calc(var(--spacing-8) * -1);
+
+        &:hover {
+          background-color: var(--color-button-container) !important;
+        }
       }
     }
   }

--- a/themes/camisa/assets/core.shop-button.js
+++ b/themes/camisa/assets/core.shop-button.js
@@ -121,8 +121,8 @@ if (!customElements.get("ui-shop-button")) {
       try {
         const response = await youcanjs.checkout.placeExpressCheckoutOrder({
           quantity,
-          fields,
-          ...(bundleId ? { bundleId, isBundle: true } : { productVariantId, attachedImage }),
+          fields: { ...fields, ...(attachedImage && { attachedImage }) },
+          ...(bundleId ? { bundleId, isBundle: true } : { productVariantId }),
         });
 
         response

--- a/themes/camisa/assets/core.variants.css
+++ b/themes/camisa/assets/core.variants.css
@@ -211,3 +211,20 @@
     opacity:0.5;
     pointer-events:none;
   }
+  ui-variants .upload-output{
+    position:relative;
+    width:-moz-fit-content;
+    width:fit-content;
+    height:80px;
+  }
+  ui-variants .upload-output img{
+    -o-object-fit:cover;
+       object-fit:cover;
+    border:1px solid var(--color-surface-variant);
+    border-radius:max(0px, min(var(--radius-input), var(--radius-16)));
+  }
+  ui-variants .upload-output button{
+    position:absolute;
+    inset-inline-end:calc(var(--spacing-8) * -1);
+    inset-block-end:calc(var(--spacing-8) * -1);
+  }

--- a/themes/camisa/assets/core.variants.css
+++ b/themes/camisa/assets/core.variants.css
@@ -228,3 +228,6 @@
     inset-inline-end:calc(var(--spacing-8) * -1);
     inset-block-end:calc(var(--spacing-8) * -1);
   }
+  ui-variants:not(#\#) .upload-output button:hover{
+    background-color:var(--color-button-container) !important;
+  }

--- a/themes/camisa/assets/main.css
+++ b/themes/camisa/assets/main.css
@@ -1551,7 +1551,8 @@ button[ui-slot=link-button]:not(#\#):not(#\#):not(#\#):not(#\#):not(#\#):not(#\#
     transition:all 500ms cubic-bezier(0.27, 1.06, 0.18, 1);
     transition:all var(--transition-standard-default-spatial);
     border:1px dashed color-mix(in srgb, var(--color-on-surface-variant) 38%, transparent);
-    border-radius:var(--radius-input);
+    border-radius:max(0px, min(var(--radius-input), 16px));
+    border-radius:max(0px, min(var(--radius-input), var(--radius-16)));
     cursor:pointer;
     gap:calc(24px - 4px);
     gap:calc(var(--spacing-24) - var(--spacing-4));
@@ -2285,7 +2286,8 @@ button[ui-slot=link-button]:not(#\#):not(#\#):not(#\#):not(#\#):not(#\#):not(#\#
     transition:all 500ms cubic-bezier(0.27, 1.06, 0.18, 1);
     transition:all var(--transition-standard-default-spatial);
     border:1px solid var(--color-surface-variant);
-    border-radius:var(--radius-input);
+    border-radius:max(0px, min(var(--radius-input), 16px));
+    border-radius:max(0px, min(var(--radius-input), var(--radius-16)));
     outline:2px solid transparent;
     outline-offset:1px;
     background-color:transparent;

--- a/themes/camisa/assets/section.product.js
+++ b/themes/camisa/assets/section.product.js
@@ -187,7 +187,12 @@ if (!customElements.get("ui-product")) {
       const fileSizeInKB = file.size / Product.BYTES_IN_KB;
       const fileSizeInMB = fileSizeInKB / Product.KB_IN_MB;
 
-      if (fileSizeInMB > Product.MAXIMUM_FILE_SIZE) return null;
+      if (fileSizeInMB > Product.MAXIMUM_FILE_SIZE) {
+        const message = window.errorStrings.large_file;
+        toast.show(message.replace("[file]", `"${file.name}"`), "error");
+
+        return;
+      }
 
       return fileInput
         ? new Promise((resolve) => {

--- a/themes/camisa/snippets/core.variants.liquid
+++ b/themes/camisa/snippets/core.variants.liquid
@@ -125,6 +125,20 @@
           </div>
           <div ui-slot="file-upload-button">{{ 'product.upload_image.trigger' | t }}</div>
         </label>
+        <div class="upload-output" hidden>
+          <img src="" alt="" width="80" height="80">
+          <button
+            type="button"
+            ui-slot="button"
+            data-variant="error"
+            data-mode="lighter"
+            data-size="xs"
+            data-as-icon
+            aria-label="remove"
+          >
+            {% render 'misc.icon', name: 'hgi-cancel-01' %}
+          </button>
+        </div>
       {% endif %}
     </div>
   {% endfor %}

--- a/themes/camisa/styles/components/form/file-upload.scss
+++ b/themes/camisa/styles/components/form/file-upload.scss
@@ -22,9 +22,8 @@
   align-items: center;
   padding: var(--spacing-32);
   transition: all var(--transition-standard-default-spatial);
-  border: 1px dashed
-    color-mix(in srgb, var(--color-on-surface-variant) 38%, transparent);
-  border-radius: var(--radius-input);
+  border: 1px dashed color-mix(in srgb, var(--color-on-surface-variant) 38%, transparent);
+  border-radius: clamp(0px, var(--radius-input), var(--radius-16));
   cursor: pointer;
   gap: calc(var(--spacing-24) - var(--spacing-4));
 

--- a/themes/camisa/styles/components/form/textarea.scss
+++ b/themes/camisa/styles/components/form/textarea.scss
@@ -10,7 +10,7 @@
   padding: var(--spacing-10) var(--spacing-12);
   transition: all var(--transition-standard-default-spatial);
   border: 1px solid var(--color-surface-variant);
-  border-radius: var(--radius-input);
+  border-radius: clamp(0px, var(--radius-input), var(--radius-16));
   outline: 2px solid transparent;
   outline-offset: 1px;
   background-color: transparent;

--- a/themes/camisa/styles/core.variants.scss
+++ b/themes/camisa/styles/core.variants.scss
@@ -252,5 +252,23 @@
         }
       }
     }
+
+    .upload-output {
+      position: relative;
+      width: fit-content;
+      height: 80px;
+
+      img {
+        object-fit: cover;
+        border: 1px solid var(--color-surface-variant);
+        border-radius: clamp(0px, var(--radius-input), var(--radius-16));
+      }
+
+      button {
+        position: absolute;
+        inset-inline-end: calc(var(--spacing-8) * -1);
+        inset-block-end: calc(var(--spacing-8) * -1);
+      }
+    }
   }
 }

--- a/themes/camisa/styles/core.variants.scss
+++ b/themes/camisa/styles/core.variants.scss
@@ -268,6 +268,10 @@
         position: absolute;
         inset-inline-end: calc(var(--spacing-8) * -1);
         inset-block-end: calc(var(--spacing-8) * -1);
+
+        &:hover {
+          background-color: var(--color-button-container) !important;
+        }
       }
     }
   }

--- a/themes/chameleon/assets/core.product-button.js
+++ b/themes/chameleon/assets/core.product-button.js
@@ -97,8 +97,8 @@ if (!customElements.get("ui-product-button")) {
       try {
         const response = await youcanjs.checkout.placeExpressCheckoutOrder({
           quantity,
-          fields,
-          ...(bundleId ? { bundleId, isBundle: true } : { productVariantId, attachedImage }),
+          fields: { ...fields, ...(attachedImage && { attachedImage }) },
+          ...(bundleId ? { bundleId, isBundle: true } : { productVariantId }),
         });
 
         response

--- a/themes/chameleon/assets/section.product.js
+++ b/themes/chameleon/assets/section.product.js
@@ -141,7 +141,12 @@ if (!customElements.get("ui-product")) {
       const fileSizeInKB = file.size / Product.BYTES_IN_KB;
       const fileSizeInMB = fileSizeInKB / Product.KB_IN_MB;
 
-      if (fileSizeInMB > Product.MAXIMUM_FILE_SIZE) return null;
+      if (fileSizeInMB > Product.MAXIMUM_FILE_SIZE) {
+        const message = window.errorStrings.large_file;
+        toast.show(message.replace("[file]", `"${file.name}"`), "error");
+
+        return;
+      }
 
       return fileInput
         ? new Promise((resolve) => {

--- a/themes/mono/assets/core.shop-button.js
+++ b/themes/mono/assets/core.shop-button.js
@@ -144,8 +144,8 @@ if (!customElements.get("ui-shop-button")) {
       try {
         const response = await youcanjs.checkout.placeExpressCheckoutOrder({
           quantity,
-          fields,
-          ...(bundleId ? { bundleId, isBundle: true } : { productVariantId, attachedImage }),
+          fields: { ...fields, ...(attachedImage && { attachedImage }) },
+          ...(bundleId ? { bundleId, isBundle: true } : { productVariantId }),
         });
 
         return new Promise((resolve) => {

--- a/themes/mono/assets/core.variants.css
+++ b/themes/mono/assets/core.variants.css
@@ -160,3 +160,20 @@ ui-variants [ui-variant][ui-variant=radio_buttons] .options .opt:has(> input[typ
   opacity:0.5;
   pointer-events:none;
 }
+ui-variants [ui-variant] .upload-output{
+  position:relative;
+  width:-moz-fit-content;
+  width:fit-content;
+  height:80px;
+}
+ui-variants [ui-variant] .upload-output img{
+  -o-object-fit:cover;
+     object-fit:cover;
+  border:1px solid currentcolor;
+  border-radius:max(0px, min(var(--radius-button), var(--radius-16)));
+}
+ui-variants [ui-variant] .upload-output button{
+  position:absolute;
+  inset-inline-end:calc(var(--spacing-6) * -1);
+  inset-block-end:var(--spacing-6);
+}

--- a/themes/mono/assets/main.css
+++ b/themes/mono/assets/main.css
@@ -1844,7 +1844,8 @@ button[ui-slot=link-button]{
   transition:all 500ms cubic-bezier(0.27, 1.06, 0.18, 1);
   transition:all var(--transition-standard-default-spatial);
   border:1px dashed var(--color-primary);
-  border-radius:var(--radius-input);
+  border-radius:max(0px, min(var(--radius-button), 16px));
+  border-radius:max(0px, min(var(--radius-button), var(--radius-16)));
   background-color:transparent;
   cursor:pointer;
   gap:calc(24px - 4px);
@@ -1900,15 +1901,9 @@ button[ui-slot=link-button]{
   height:32px;
   padding-inline:10px;
   padding-inline:var(--spacing-10);
-  border:1px solid var(--color-surface-variant);
-  border-radius:8px;
-  border-radius:var(--radius-8);
-  background-color:var(--color-background);
+  border:1px solid currentcolor;
+  border-radius:var(--radius-button);
   color:var(--color-on-surface-variant);
-}
-
-[ui-slot=file-upload]:hover{
-  background-color:var(--color-surface-container-high);
 }
 [ui-slot=hint]{
   display:flex;
@@ -2201,8 +2196,8 @@ button[ui-slot=link-button]{
   transition:350ms cubic-bezier(0.42, 1.67, 0.21, 0.9);
   transition:var(--transition-expressive-fast-spatial);
   border:1px solid var(--color-surface-variant);
-  border-radius:clamp(0px, var(--radius-input) * 2, 16px);
-  border-radius:clamp(0px, var(--radius-input) * 2, var(--radius-16));
+  border-radius:clamp(0px, var(--radius-button) * 2, 16px);
+  border-radius:clamp(0px, var(--radius-button) * 2, var(--radius-16));
   background-color:var(--color-background);
   box-shadow:0 16px 32px -12px color-mix(in srgb, var(--color-on-background) 8%, transparent);
 }
@@ -2211,7 +2206,7 @@ button[ui-slot=link-button]{
   width:100%;
   overflow:hidden;
   border:none;
-  border-radius:var(--radius-input);
+  border-radius:var(--radius-button);
   background-color:transparent;
 }
 
@@ -2309,7 +2304,7 @@ button[ui-slot=link-button]{
   gap:var(--spacing-8);
   padding-inline:12px;
   padding-inline:var(--spacing-12);
-  border-radius:calc(var(--radius-input) * 1.2);
+  border-radius:calc(var(--radius-button) * 1.2);
 }
 
 [ui-slot*=select][data-size=md] [ui-slot=select-trigger]{
@@ -2318,7 +2313,7 @@ button[ui-slot=link-button]{
   gap:var(--spacing-8);
   padding-inline:10px;
   padding-inline:var(--spacing-10);
-  border-radius:var(--radius-input);
+  border-radius:var(--radius-button);
 }
 
 [ui-slot*=select][data-size=sm] [ui-slot=select-trigger]{
@@ -2327,7 +2322,7 @@ button[ui-slot=link-button]{
   gap:var(--spacing-6);
   padding-inline:8px;
   padding-inline:var(--spacing-8);
-  border-radius:var(--radius-input);
+  border-radius:var(--radius-button);
 }
 
 [ui-slot*=select]{

--- a/themes/mono/assets/section.product.js
+++ b/themes/mono/assets/section.product.js
@@ -204,7 +204,12 @@ if (!customElements.get("ui-product")) {
       const fileSizeInKB = file.size / Product.BYTES_IN_KB;
       const fileSizeInMB = fileSizeInKB / Product.KB_IN_MB;
 
-      if (fileSizeInMB > Product.MAXIMUM_FILE_SIZE) return null;
+      if (fileSizeInMB > Product.MAXIMUM_FILE_SIZE) {
+        const message = window.errorStrings.large_file;
+        toast.show(message.replace("[file]", `"${file.name}"`), "error");
+
+        return;
+      }
 
       return fileInput
         ? new Promise((resolve) => {

--- a/themes/mono/locales/ar.json
+++ b/themes/mono/locales/ar.json
@@ -66,7 +66,12 @@
       "collections": "المجموعات"
     },
     "details": "التفاصيل",
-    "variants": "الخيارات"
+    "variants": "الخيارات",
+    "upload_image": {
+      "label": "اضغط هنا لاختيار صورة",
+      "accept": "JPG، JPEG، PNG، GIF وWEBP. الحجم الأقصى: 2 ميجابايت.",
+      "trigger": "تصفح الملف"
+    }
   },
   "reviews": {
     "reviews": "مراجعة",

--- a/themes/mono/locales/en.default.json
+++ b/themes/mono/locales/en.default.json
@@ -66,7 +66,12 @@
       "collections": "Collections"
     },
     "details": "Details",
-    "variants": "Variants"
+    "variants": "Variants",
+    "upload_image": {
+      "label": "Click here to choose image",
+      "accept": "JPG, JPEG, PNG, GIF and WEBP. Max 2MB.",
+      "trigger": "Browse File"
+    }
   },
   "reviews": {
     "reviews": "Reviews",

--- a/themes/mono/locales/fr.json
+++ b/themes/mono/locales/fr.json
@@ -66,7 +66,12 @@
       "collections": "Collections"
     },
     "details": "Détails",
-    "variants": "Variantes"
+    "variants": "Variantes",
+    "upload_image": {
+      "label": "Cliquez ici pour choisir une image",
+      "accept": "JPG, JPEG, PNG, GIF et WEBP. Taille maximale : 2 Mo.",
+      "trigger": "Parcourir le fichier"
+    }
   },
   "reviews": {
     "reviews": "Avis",

--- a/themes/mono/snippets/core.variants.liquid
+++ b/themes/mono/snippets/core.variants.liquid
@@ -121,14 +121,27 @@
           <input type="file" name="{{ unique_name }}" accept="image/png, image/gif, image/jpg, image/jpeg, image/webp">
 
           <div ui-slot="file-upload-icon">
-            <i class="hgi hgi-stroke hgi-cloud-upload"></i>
+            <i class="hgi hgi-stroke hgi-upload-05"></i>
           </div>
           <div ui-slot="file-upload-content">
-            <h4 ui-slot="file-upload-label">{{ 'product.upload_image.label' | t }}</h4>
-            <p ui-slot="file-upload-description">{{ 'product.upload_image.accept' | t }}</p>
+            <h4 ui-slot="file-upload-label">{{ 'product_information.upload_image.label' | t }}</h4>
+            <p ui-slot="file-upload-description">{{ 'product_information.upload_image.accept' | t }}</p>
           </div>
-          <div ui-slot="file-upload-button">{{ 'product.upload_image.trigger' | t }}</div>
+          <div ui-slot="file-upload-button">{{ 'product_information.upload_image.trigger' | t }}</div>
         </label>
+        <div class="upload-output" hidden>
+          <img src="" alt="" width="65" height="65">
+          <button
+            type="button"
+            ui-slot="button"
+            data-mode="3d"
+            data-size="xs"
+            data-as-icon
+            aria-label="Remove"
+          >
+            {% render 'misc.icon', name: 'hgi-delete-02' %}
+          </button>
+        </div>
       {% endif %}
     </div>
   {% endfor %}

--- a/themes/mono/styles/components/form/file-upload.scss
+++ b/themes/mono/styles/components/form/file-upload.scss
@@ -23,7 +23,7 @@
   padding: var(--spacing-32);
   transition: all var(--transition-standard-default-spatial);
   border: 1px dashed var(--color-primary);
-  border-radius: var(--radius-input);
+  border-radius: clamp(0px, var(--radius-button), var(--radius-16));
   background-color: transparent;
   cursor: pointer;
   gap: calc(var(--spacing-24) - var(--spacing-4));
@@ -67,13 +67,8 @@
     align-items: center;
     height: 32px;
     padding-inline: var(--spacing-10);
-    border: 1px solid var(--color-surface-variant);
-    border-radius: var(--radius-8);
-    background-color: var(--color-background);
+    border: 1px solid currentcolor;
+    border-radius: var(--radius-button);
     color: var(--color-on-surface-variant);
-  }
-
-  &:hover {
-    background-color: var(--color-surface-container-high);
   }
 }

--- a/themes/mono/styles/components/form/select.scss
+++ b/themes/mono/styles/components/form/select.scss
@@ -111,7 +111,7 @@
     padding: var(--spacing-8);
     transition: var(--transition-expressive-fast-spatial);
     border: 1px solid var(--color-surface-variant);
-    border-radius: clamp(0px, calc(var(--radius-input) * 2), var(--radius-16));
+    border-radius: clamp(0px, calc(var(--radius-button) * 2), var(--radius-16));
     background-color: var(--color-background);
     box-shadow: 0 16px 32px -12px color-mix(in srgb, var(--color-on-background) 8%, transparent);
 
@@ -120,7 +120,7 @@
       width: 100%;
       overflow: hidden;
       border: none;
-      border-radius: var(--radius-input);
+      border-radius: var(--radius-button);
       background-color: transparent;
 
       & > label {
@@ -205,7 +205,7 @@
       height: 40px;
       gap: var(--spacing-8);
       padding-inline: var(--spacing-12);
-      border-radius: calc(var(--radius-input) * 1.2);
+      border-radius: calc(var(--radius-button) * 1.2);
     }
   }
 
@@ -214,7 +214,7 @@
       height: 36px;
       gap: var(--spacing-8);
       padding-inline: var(--spacing-10);
-      border-radius: var(--radius-input);
+      border-radius: var(--radius-button);
     }
   }
 
@@ -223,7 +223,7 @@
       height: 32px;
       gap: var(--spacing-6);
       padding-inline: var(--spacing-8);
-      border-radius: var(--radius-input);
+      border-radius: var(--radius-button);
     }
   }
 

--- a/themes/mono/styles/core.variants.scss
+++ b/themes/mono/styles/core.variants.scss
@@ -204,5 +204,23 @@ ui-variants {
         }
       }
     }
+
+    .upload-output {
+      position: relative;
+      width: fit-content;
+      height: 80px;
+
+      img {
+        object-fit: cover;
+        border: 1px solid currentcolor;
+        border-radius: clamp(0px, var(--radius-button), var(--radius-16));
+      }
+
+      button {
+        position: absolute;
+        inset-inline-end: calc(var(--spacing-6) * -1);
+        inset-block-end: var(--spacing-6);
+      }
+    }
   }
 }


### PR DESCRIPTION
## Prerequisites

- [ ] Check this branch locally and run `pnpm run release`
- [ ] 3 new files will be generated in this format `theme name + date + .zip`
- [ ] Upload generated file locally or in seller-area test env

## QA Steps

- [ ] Navigate to a product with a variant upload (Bella/Camisa/Mono themes)
- [ ] Verify if you can see the uploaded image + try to remove it

## Preview

<img width="741" height="343" alt="Screenshot 2026-07-07 at 14 04 51" src="https://github.com/user-attachments/assets/85591d73-4149-4d84-872d-d8dcf567549c" />


## Note

Leave empty when you have nothing to say.
