### PR TITLE
fix(mono): testimonials > default alt value

### DIFF
--- a/.changeset/ready-guests-melt.md
+++ b/.changeset/ready-guests-melt.md
@@ -1,0 +1,5 @@
+---
+"mono": patch
+---
+
+Mono > testimonials > fix default alt value

--- a/themes/mono/sections/testimonials.liquid
+++ b/themes/mono/sections/testimonials.liquid
@@ -79,7 +79,7 @@
                 {% if block.settings.image %}
                   <img
                     src="{{ block.settings.image.src }}"
-                    alt="{{ block.settings.image_alt | default: 'Testimonial {{ forloop.index }}' }}"
+                    alt="{{ block.settings.image_alt | default: 'Testimonial ' | append: forloop.index }}"
                     height="100%"
                     width="100%"
                     loading="lazy"


### PR DESCRIPTION
## Prerequisites

- [ ] Check this branch locally and run `pnpm run release`
- [ ] 3 new files will be generated in this format `theme name + date + .zip`
- [ ] Upload generated file locally or in seller-area test env

## QA Steps

- [ ] Go to your theme editor (MONO as your active theme)
- [ ] Select a testimonial block, try to add an image for it and hit `save`
- [ ] Verify if the new changes applied, and store works fine (no blank page)

## Note

Leave empty when you have nothing to say.
