### PR TITLE
fix(mono): add missing pixels (cart + product)

### DIFF
--- a/.changeset/thin-trams-glow.md
+++ b/.changeset/thin-trams-glow.md
@@ -1,0 +1,5 @@
+---
+"mono": patch
+---
+
+Mono > Add missing pixels

--- a/themes/mono/sections/cart.liquid
+++ b/themes/mono/sections/cart.liquid
@@ -165,7 +165,7 @@
           <span class="label">{{ 'cart.summary.total' | t }}</span>
           <span class="value" ui-summary-box="total">{{ cart.discounted_sub_total | default: 0 | money }}</span>
         </div>
-        <a ui-slot="button" data-mode="filled" data-size="lg" href="{{ cart.cart_submit_url }}">
+        <a ui-slot="button" data-mode="filled" data-size="lg" href="{{ cart.cart_submit_url }}" id="checkout-button">
           {{ 'cart.summary.checkout' | t }}
         </a>
       </div>
@@ -178,6 +178,27 @@
     {% render 'misc.empty', type: 'cart', hidden: true %}
   {% endunless %}
 </div>
+
+{% if cart %}
+  {% javascript %}
+    document.addEventListener('DOMContentLoaded', function () {
+      const checkoutButton = document.querySelector('#checkout-button');
+
+      if (!checkoutButton) return;
+
+      const cart = JSON.parse({{ cart | json }});
+      let updatedCart = cart;
+
+      subscribe(PUB_SUB_EVENTS.cartUpdate, function (payload) {
+        updatedCart = payload.cartData;
+      });
+
+      checkoutButton.addEventListener('click', function () {
+        window.Dotshop.pixels.publish('initiate-checkout', updatedCart);
+      });
+    });
+  {% endjavascript %}
+{% endif %}
 
 {% schema %}
 {

--- a/themes/mono/sections/product-information.liquid
+++ b/themes/mono/sections/product-information.liquid
@@ -198,6 +198,16 @@
   {% endjavascript %}
 {% endif %}
 
+{% if product %}
+  {% javascript %}
+    const globalProduct = JSON.parse({{ product | json }});
+
+    document.addEventListener('DOMContentLoaded', () => {
+      window.Dotshop.pixels.publish('view-content', globalProduct);
+    });
+  {% endjavascript %}
+{% endif %}
+
 {% schema %}
 {
   "label": "t:sections.product_information.label",


### PR DESCRIPTION
## Prerequisites

- [ ] Check this branch locally and run `pnpm run release`
- [ ] 3 new files will be generated in this format `theme name + date + .zip`
- [ ] Upload generated file locally or in seller-area test env

## QA Steps

- [ ] Make sure that you have at least one pixel added in your settings
- [ ] Go to your store `/products/{{ id }} `or `/cart`
- [ ] Verify if the pixels fired when you visit a product page (`ViewContent`) or when you clicked on the checkout button (`Initial Checkout`)

## Note

Leave empty when you have nothing to say.
