### PR TITLE
fix(kinder): avg rating label not translated

### DIFF
--- a/.changeset/fancy-papers-follow.md
+++ b/.changeset/fancy-papers-follow.md
@@ -1,0 +1,5 @@
+---
+"kinder": patch
+---
+
+Add missing avg rating label translation

--- a/themes/kinder/assets/block.product.css
+++ b/themes/kinder/assets/block.product.css
@@ -35,7 +35,7 @@
   [ui-block=product] .media[data-image-ratio=landscape]{
     aspect-ratio:4/3;
   }
-  [ui-block=product] .media > a img{
+  [ui-block=product] .media > img{
     -o-object-fit:cover;
        object-fit:cover;
     transition:var(--transition-expressive-default-spatial);

--- a/themes/kinder/locales/ar.json
+++ b/themes/kinder/locales/ar.json
@@ -156,6 +156,7 @@
     "title": "تقييمات",
     "anonymous": "مجهول",
     "product_rating": "تقييم المنتج",
+    "average_rating": "متوسط التقييم",
     "reviewed_by": "مراجعة من",
     "on": "في",
     "add_review": {

--- a/themes/kinder/locales/en.default.json
+++ b/themes/kinder/locales/en.default.json
@@ -156,6 +156,7 @@
     "title": "Reviews",
     "anonymous": "Anonymous",
     "product_rating": "Product Rating",
+    "average_rating": "Average rating",
     "reviewed_by": "Reviewed by",
     "on": "on",
     "add_review": {

--- a/themes/kinder/locales/fr.json
+++ b/themes/kinder/locales/fr.json
@@ -156,6 +156,7 @@
     "title": "Avis",
     "anonymous": "Anonyme",
     "product_rating": "Note du produit",
+    "average_rating": "Note moyenne",
     "reviewed_by": "Avis de",
     "on": "le",
     "add_review": {

--- a/themes/kinder/sections/reviews.liquid
+++ b/themes/kinder/sections/reviews.liquid
@@ -67,7 +67,7 @@
       </div>
       <div class="avg-rating">
         <div class="rating">
-          <span class="label">Average rating:</span>
+          <span class="label">{{ 'reviews.average_rating' | t }}:</span>
           <span class="avg">{{ product.averageRating }}</span>
           <p class="total-reviews">(<span ui-reviews="total">-</span> {{ 'reviews.title' | t }})</p>
         </div>

--- a/themes/kinder/snippets/block.product.liquid
+++ b/themes/kinder/snippets/block.product.liquid
@@ -26,36 +26,34 @@
   data-alignment="{{ settings.product_alignment }}"
   {{ attributes }}
 >
-  <div class="media" data-image-ratio="{{ settings.product_image_ratio }}">
-    <a href="{{ product.url }}">
-      {% if product.preview_image %}
-        <img
-          srcset="
-            {{ product.preview_image.medium }} 480w,
-            {{ product.preview_image.large }} 800w,
-            {{ product.preview_image.original }} 1200w
-          "
-          sizes="
-            (max-width: 640px) 50vw,
-            (max-width: 768px) 33vw,
-            (max-width: 1024px) 25vw,
-            33vw
-          "
-          src="{{ product.preview_image.original }}"
-          alt="{{ product.name }}"
-          height="100%"
-          width="100%"
-          {% if template.name == 'collection' or template.name == 'search' and forloop.index < 5 %}
-            loading="eager"
-          {% else %}
-            loading="lazy"
-          {% endif %}
-        >
-      {% else %}
-        {% render 'misc.image-fallback', icon_size: 40 %}
-      {% endif %}
-    </a>
-  </div>
+  <a href="{{ product.url }}" class="media" data-image-ratio="{{ settings.product_image_ratio }}">
+    {% if product.preview_image %}
+      <img
+        srcset="
+          {{ product.preview_image.medium }} 480w,
+          {{ product.preview_image.large }} 800w,
+          {{ product.preview_image.original }} 1200w
+        "
+        sizes="
+          (max-width: 640px) 50vw,
+          (max-width: 768px) 33vw,
+          (max-width: 1024px) 25vw,
+          33vw
+        "
+        src="{{ product.preview_image.original }}"
+        alt="{{ product.name }}"
+        height="100%"
+        width="100%"
+        {% if template.name == 'collection' or template.name == 'search' and forloop.index < 5 %}
+          loading="eager"
+        {% else %}
+          loading="lazy"
+        {% endif %}
+      >
+    {% else %}
+      {% render 'misc.image-fallback', icon_size: 40 %}
+    {% endif %}
+  </a>
   <div class="content">
     <div class="stats">
       {% if settings.show_discount and compare_at_price %}

--- a/themes/kinder/styles/block.product.scss
+++ b/themes/kinder/styles/block.product.scss
@@ -37,7 +37,7 @@
         aspect-ratio: 4 / 3;
       }
 
-      & > a img {
+      & > img {
         object-fit: cover;
         transition: var(--transition-expressive-default-spatial);
       }


### PR DESCRIPTION
## Prerequisites

- [ ] Check this branch locally and run `pnpm run release`
- [ ] 3 new files will be generated in this format `theme name + date + .zip`
- [ ] Upload generated file locally or in seller-area test env

## QA Steps

- [ ] Switch your store to an Arabic or French speaking country
- [ ] Go to a product page of a product
- [ ] scroll to rating section
- [ ] Ensure the label "average rating" is translated

## Note

Leave empty when you have nothing to say.
