### PR TITLE
SF-1049: Add support of "yc-sans" for all new themes

### DIFF
--- a/.changeset/cozy-rice-act.md
+++ b/.changeset/cozy-rice-act.md
@@ -1,0 +1,12 @@
+---
+"chameleon": patch
+"harmony": patch
+"camisa": patch
+"kinder": patch
+"meraki": patch
+"bella": patch
+"aura": patch
+"mono": patch
+---
+
+Add support of "yc-sans" font

--- a/themes/aura/snippets/head-config.liquid
+++ b/themes/aura/snippets/head-config.liquid
@@ -12,9 +12,7 @@
 {%- style -%}
   :root {
     /* main */
-    --yc-font-family:
-    {{ settings.font_family }},
-    sans-serif;
+    --yc-font-family: {{ settings.font_family }}, sans-serif, "yc-sans";
     --yc-inputs-shadow: 0 0 0 1px var(--yc-primary-color);
     --yc-main-shadow: rgba(0, 0, 0, 0.04) 0 0 0 1px, rgba(0, 0, 0, 0.03) 0 1px 1px, rgba(0, 0, 0, 0.03) 0 2px 2px, rgba(0, 0, 0, 0.03) 0 4px 4px, rgba(0, 0, 0, 0.03) 0 8px 8px, rgba(0, 0, 0, 0.03) 0 16px 16px;
     --yc-theme-direction: {{ settings.theme_direction }};

--- a/themes/aura/snippets/head-config.liquid
+++ b/themes/aura/snippets/head-config.liquid
@@ -12,7 +12,7 @@
 {%- style -%}
   :root {
     /* main */
-    --yc-font-family: {{ settings.font_family }}, sans-serif, "yc-sans";
+    --yc-font-family: {{ settings.font_family }}, sans-serif, yc-sans;
     --yc-inputs-shadow: 0 0 0 1px var(--yc-primary-color);
     --yc-main-shadow: rgba(0, 0, 0, 0.04) 0 0 0 1px, rgba(0, 0, 0, 0.03) 0 1px 1px, rgba(0, 0, 0, 0.03) 0 2px 2px, rgba(0, 0, 0, 0.03) 0 4px 4px, rgba(0, 0, 0, 0.03) 0 8px 8px, rgba(0, 0, 0, 0.03) 0 16px 16px;
     --yc-theme-direction: {{ settings.theme_direction }};

--- a/themes/bella/snippets/_config.liquid
+++ b/themes/bella/snippets/_config.liquid
@@ -46,7 +46,7 @@
   :root {
 
     /* Base */
-    --font-family: '{{ settings.font_family | replace: '+', ' ' }}', sans-serif, "yc-sans";
+    --font-family: '{{ settings.font_family | replace: '+', ' ' }}', sans-serif, yc-sans;
 
     {% case settings.base_size %}
       {% when 'small' %}
@@ -59,16 +59,16 @@
 
     /* Heading */
     --font-heading-scale: calc({{ settings.font_scale_headings }} / 100);
-    --font-heading-family: '{{ settings.font_family_headings | replace: '+', ' ' }}', sans-serif, "yc-sans";
+    --font-heading-family: '{{ settings.font_family_headings | replace: '+', ' ' }}', sans-serif, yc-sans;
 
     /* Subheading */
     --font-subheading-scale: calc({{ settings.font_scale_subheadings }} / 100);
-    --font-subheading-family: '{{ settings.font_family_subheadings | replace: '+', ' ' }}', sans-serif, "yc-sans";
+    --font-subheading-family: '{{ settings.font_family_subheadings | replace: '+', ' ' }}', sans-serif, yc-sans;
     --font-subheading-weight: {{ settings.font_weight_subheadings }};
     --text-subheading-transform: {{ settings.text_transform_subheadings }};
 
     /* Button */
-    --font-button-family: '{{ settings.font_family_buttons | replace: '+', ' ' }}', sans-serif, "yc-sans";
+    --font-button-family: '{{ settings.font_family_buttons | replace: '+', ' ' }}', sans-serif, yc-sans;
     --font-button-weight: {{ settings.font_weight_buttons }};
 
     /* Colors */

--- a/themes/bella/snippets/_config.liquid
+++ b/themes/bella/snippets/_config.liquid
@@ -46,7 +46,7 @@
   :root {
 
     /* Base */
-    --font-family: '{{ settings.font_family | replace: '+', ' ' }}';
+    --font-family: '{{ settings.font_family | replace: '+', ' ' }}', sans-serif, "yc-sans";
 
     {% case settings.base_size %}
       {% when 'small' %}
@@ -59,16 +59,16 @@
 
     /* Heading */
     --font-heading-scale: calc({{ settings.font_scale_headings }} / 100);
-    --font-heading-family: {{ settings.font_family_headings | replace: '+', ' ' }};
+    --font-heading-family: '{{ settings.font_family_headings | replace: '+', ' ' }}', sans-serif, "yc-sans";
 
     /* Subheading */
     --font-subheading-scale: calc({{ settings.font_scale_subheadings }} / 100);
-    --font-subheading-family: {{ settings.font_family_subheadings | replace: '+', ' ' }};
+    --font-subheading-family: '{{ settings.font_family_subheadings | replace: '+', ' ' }}', sans-serif, "yc-sans";
     --font-subheading-weight: {{ settings.font_weight_subheadings }};
     --text-subheading-transform: {{ settings.text_transform_subheadings }};
 
     /* Button */
-    --font-button-family: {{ settings.font_family_buttons | replace: '+', ' ' }};
+    --font-button-family: '{{ settings.font_family_buttons | replace: '+', ' ' }}', sans-serif, "yc-sans";
     --font-button-weight: {{ settings.font_weight_buttons }};
 
     /* Colors */

--- a/themes/camisa/snippets/_config.liquid
+++ b/themes/camisa/snippets/_config.liquid
@@ -46,7 +46,7 @@
   :root {
 
     /* Base */
-    --font-family: '{{ settings.font_family | replace: '+', ' ' }}';
+    --font-family: '{{ settings.font_family | replace: '+', ' ' }}', sans-serif, "yc-sans";
 
     {% case settings.base_size %}
       {% when 'small' %}

--- a/themes/camisa/snippets/_config.liquid
+++ b/themes/camisa/snippets/_config.liquid
@@ -46,7 +46,7 @@
   :root {
 
     /* Base */
-    --font-family: '{{ settings.font_family | replace: '+', ' ' }}', sans-serif, "yc-sans";
+    --font-family: '{{ settings.font_family | replace: '+', ' ' }}', sans-serif, yc-sans;
 
     {% case settings.base_size %}
       {% when 'small' %}

--- a/themes/chameleon/snippets/_config.liquid
+++ b/themes/chameleon/snippets/_config.liquid
@@ -32,7 +32,7 @@
 {% comment %} Tokens {% endcomment %}
 {% style %}
   :root {
-    --font-family: '{{ settings.font_family | replace: '+', ' '  }}', sans-serif;
+    --font-family: '{{ settings.font_family | replace: '+', ' '  }}', sans-serif, "yc-sans";
   }
 {% endstyle %}
 

--- a/themes/chameleon/snippets/_config.liquid
+++ b/themes/chameleon/snippets/_config.liquid
@@ -32,7 +32,7 @@
 {% comment %} Tokens {% endcomment %}
 {% style %}
   :root {
-    --font-family: '{{ settings.font_family | replace: '+', ' '  }}', sans-serif, "yc-sans";
+    --font-family: '{{ settings.font_family | replace: '+', ' '  }}', sans-serif, yc-sans;
   }
 {% endstyle %}
 

--- a/themes/harmony/snippets/head-config.liquid
+++ b/themes/harmony/snippets/head-config.liquid
@@ -12,9 +12,7 @@
 {%- style -%}
   :root {
     /* main */
-    --yc-font-family:
-    {{ settings.font_family }},
-    sans-serif;
+    --yc-font-family: {{ settings.font_family }}, sans-serif, "yc-sans";
     --yc-inputs-shadow: 0 0 0 1px var(--yc-primary-color);
     --yc-main-shadow: rgba(0, 0, 0, 0.04) 0 0 0 1px, rgba(0, 0, 0, 0.03) 0 1px 1px, rgba(0, 0, 0, 0.03) 0 2px 2px, rgba(0, 0, 0, 0.03) 0 4px 4px, rgba(0, 0, 0, 0.03) 0 8px 8px, rgba(0, 0, 0, 0.03) 0 16px 16px;
     --yc-theme-direction: {{ settings.theme_direction }};

--- a/themes/harmony/snippets/head-config.liquid
+++ b/themes/harmony/snippets/head-config.liquid
@@ -12,7 +12,7 @@
 {%- style -%}
   :root {
     /* main */
-    --yc-font-family: {{ settings.font_family }}, sans-serif, "yc-sans";
+    --yc-font-family: {{ settings.font_family }}, sans-serif, yc-sans;
     --yc-inputs-shadow: 0 0 0 1px var(--yc-primary-color);
     --yc-main-shadow: rgba(0, 0, 0, 0.04) 0 0 0 1px, rgba(0, 0, 0, 0.03) 0 1px 1px, rgba(0, 0, 0, 0.03) 0 2px 2px, rgba(0, 0, 0, 0.03) 0 4px 4px, rgba(0, 0, 0, 0.03) 0 8px 8px, rgba(0, 0, 0, 0.03) 0 16px 16px;
     --yc-theme-direction: {{ settings.theme_direction }};

--- a/themes/kinder/snippets/_config.liquid
+++ b/themes/kinder/snippets/_config.liquid
@@ -48,12 +48,12 @@
     --page-width: {{ settings.page_width }}px;
 
     /* Base */
-    --font-family: '{{ settings.font_family | replace: '+', ' ' }}', sans-serif, "yc-sans";
+    --font-family: '{{ settings.font_family | replace: '+', ' ' }}', sans-serif, yc-sans;
     --font-body-scale: {{ settings.body_scale | divided_by: 100.0 }};
 
     /* Heading */
     --font-heading-scale: calc({{ settings.font_scale_headings }} / 100);
-    --font-heading-family: '{{ settings.font_family_headings | replace: '+', ' ' }}', sans-serif, "yc-sans";
+    --font-heading-family: '{{ settings.font_family_headings | replace: '+', ' ' }}', sans-serif, yc-sans;
 
     /* Colors */
     --brand-lightness: {{ settings.main_color.lightness | divided_by: 100 }};

--- a/themes/kinder/snippets/_config.liquid
+++ b/themes/kinder/snippets/_config.liquid
@@ -48,12 +48,12 @@
     --page-width: {{ settings.page_width }}px;
 
     /* Base */
-    --font-family: '{{ settings.font_family | replace: '+', ' ' }}';
+    --font-family: '{{ settings.font_family | replace: '+', ' ' }}', sans-serif, "yc-sans";
     --font-body-scale: {{ settings.body_scale | divided_by: 100.0 }};
 
     /* Heading */
     --font-heading-scale: calc({{ settings.font_scale_headings }} / 100);
-    --font-heading-family: {{ settings.font_family_headings | replace: '+', ' ' }};
+    --font-heading-family: '{{ settings.font_family_headings | replace: '+', ' ' }}', sans-serif, "yc-sans";
 
     /* Colors */
     --brand-lightness: {{ settings.main_color.lightness | divided_by: 100 }};

--- a/themes/meraki/snippets/head-config.liquid
+++ b/themes/meraki/snippets/head-config.liquid
@@ -12,9 +12,7 @@
 {%- style -%}
   :root {
     /* main */
-    --yc-font-family:
-    {{ settings.font_family }},
-    sans-serif;
+    --yc-font-family: {{ settings.font_family }}, sans-serif, "yc-sans";
     --yc-inputs-shadow: 0 0 0 1px var(--yc-primary-color);
     --yc-main-shadow: rgba(0, 0, 0, 0.04) 0 0 0 1px, rgba(0, 0, 0, 0.03) 0 1px 1px, rgba(0, 0, 0, 0.03) 0 2px 2px, rgba(0, 0, 0, 0.03) 0 4px 4px, rgba(0, 0, 0, 0.03) 0 8px 8px, rgba(0, 0, 0, 0.03) 0 16px 16px;
     --yc-theme-direction: {{ settings.theme_direction }};

--- a/themes/meraki/snippets/head-config.liquid
+++ b/themes/meraki/snippets/head-config.liquid
@@ -12,7 +12,7 @@
 {%- style -%}
   :root {
     /* main */
-    --yc-font-family: {{ settings.font_family }}, sans-serif, "yc-sans";
+    --yc-font-family: {{ settings.font_family }}, sans-serif, yc-sans;
     --yc-inputs-shadow: 0 0 0 1px var(--yc-primary-color);
     --yc-main-shadow: rgba(0, 0, 0, 0.04) 0 0 0 1px, rgba(0, 0, 0, 0.03) 0 1px 1px, rgba(0, 0, 0, 0.03) 0 2px 2px, rgba(0, 0, 0, 0.03) 0 4px 4px, rgba(0, 0, 0, 0.03) 0 8px 8px, rgba(0, 0, 0, 0.03) 0 16px 16px;
     --yc-theme-direction: {{ settings.theme_direction }};

--- a/themes/mono/snippets/_config.liquid
+++ b/themes/mono/snippets/_config.liquid
@@ -57,15 +57,6 @@
     --font-family: '{{ settings.body_font | replace: '+', ' ' }}', sans-serif, "yc-sans";
     --font-heading-family: '{{ settings.heading_font | replace: '+', ' ' }}', sans-serif, "yc-sans";
 
-    {% case settings.base_size %}
-      {% when 'small' %}
-        --font-base-size: var(--font-body-sm);
-      {% when 'medium' %}
-        --font-base-size: var(--font-body-md);
-      {% else %}
-        --font-base-size: var(--font-body-lg);
-    {% endcase %}
-
     /* Spacing */
     --section-spacing: {{ settings.section_spacing }}px;
 

--- a/themes/mono/snippets/_config.liquid
+++ b/themes/mono/snippets/_config.liquid
@@ -54,8 +54,17 @@
 {% style %}
   :root {
     /* Base */
-    --font-family: '{{ settings.body_font | replace: '+', ' ' }}';
-    --font-heading-family: '{{ settings.heading_font | replace: '+', ' ' }}';
+    --font-family: '{{ settings.body_font | replace: '+', ' ' }}', sans-serif, "yc-sans";
+    --font-heading-family: '{{ settings.heading_font | replace: '+', ' ' }}', sans-serif, "yc-sans";
+
+    {% case settings.base_size %}
+      {% when 'small' %}
+        --font-base-size: var(--font-body-sm);
+      {% when 'medium' %}
+        --font-base-size: var(--font-body-md);
+      {% else %}
+        --font-base-size: var(--font-body-lg);
+    {% endcase %}
 
     /* Spacing */
     --section-spacing: {{ settings.section_spacing }}px;

--- a/themes/mono/snippets/_config.liquid
+++ b/themes/mono/snippets/_config.liquid
@@ -54,8 +54,8 @@
 {% style %}
   :root {
     /* Base */
-    --font-family: '{{ settings.body_font | replace: '+', ' ' }}', sans-serif, "yc-sans";
-    --font-heading-family: '{{ settings.heading_font | replace: '+', ' ' }}', sans-serif, "yc-sans";
+    --font-family: '{{ settings.body_font | replace: '+', ' ' }}', sans-serif, yc-sans;
+    --font-heading-family: '{{ settings.heading_font | replace: '+', ' ' }}', sans-serif, yc-sans;
 
     /* Spacing */
     --section-spacing: {{ settings.section_spacing }}px;


### PR DESCRIPTION
## Prerequisites

- [ ] Check this branch locally and run `pnpm run release`
- [ ] 3 new files will be generated in this format `theme name + date + .zip`
- [ ] Upload generated file locally or in seller-area test env

## QA Steps

- [ ] Go to /something
- [ ] Verify said thing

## Note

Leave empty when you have nothing to say.
