### PR TITLE
fix(kinder): White shade color variants appear red-ish

### DIFF
--- a/.changeset/short-ads-relate.md
+++ b/.changeset/short-ads-relate.md
@@ -1,0 +1,5 @@
+---
+"kinder": patch
+---
+
+Refactor how we derrive shade color from bg color

--- a/themes/kinder/assets/block.collection.css
+++ b/themes/kinder/assets/block.collection.css
@@ -1,6 +1,6 @@
 @layer snippets{
   [ui-block=collection]{
-    --bg-shade-color:oklch(from var(--bg-color) calc(l - 0.0225) calc(c + 0.0181) calc(h + 6.6));
+    --bg-shade-color:oklch(from var(--bg-color) calc(l - 0.0225 * (1 - 2 * clamp(0, (0.5 - l) * 9999, 1))) calc(c + 0.0181 * clamp(0, c * 200, 1)) calc(h + 6.6));
     display:flex;
     gap:var(--spacing-16);
     flex-direction:column;

--- a/themes/kinder/assets/block.collection.css
+++ b/themes/kinder/assets/block.collection.css
@@ -1,6 +1,6 @@
 @layer snippets{
   [ui-block=collection]{
-    --bg-shade-color:oklch(from var(--bg-color) calc(l - 0.0225 * (1 - 2 * clamp(0, (0.5 - l) * 9999, 1))) calc(c + 0.0181 * clamp(0, c * 200, 1)) calc(h + 6.6));
+    --bg-shade-color:oklch(from var(--bg-color) calc(l - 0.0225 * (1 - 2 * clamp(0, (0.5 - l) * 9999, 1)) + 0.16 * clamp(0, (0.25 - l) * 4, 1)) calc(c + 0.0181 * clamp(0, c * 200, 1)) calc(h + 6.6));
     display:flex;
     gap:var(--spacing-16);
     flex-direction:column;

--- a/themes/kinder/assets/block.product.css
+++ b/themes/kinder/assets/block.product.css
@@ -2,10 +2,10 @@
 @layer snippets{
   [ui-block=product]{
     --bg-color:#fefefe;
-    --bg-shade-color:oklch(from var(--bg-color) calc(l - 0.018 * (1 - 2 * clamp(0, (0.5 - l) * 9999, 1))) c h);
+    --bg-shade-color:oklch(from var(--bg-color) calc(l - 0.018 * (1 - 2 * clamp(0, (0.5 - l) * 9999, 1)) + 0.16 * clamp(0, (0.25 - l) * 4, 1)) c h);
     --fg-color:oklch(from var(--bg-color) clamp(0, calc((0.5 - l) * 9999), 1) 0 none);
     --quantity-bg:var(--bg-shade-color);
-    --shadow-color:oklch(from var(--bg-color) calc(l - 0.0225 * (1 - 2 * clamp(0, (0.5 - l) * 9999, 1))) calc(c + 0.0181 * clamp(0, c * 200, 1)) calc(h + 6.6));
+    --shadow-color:oklch(from var(--bg-color) calc(l - 0.0225 * (1 - 2 * clamp(0, (0.5 - l) * 9999, 1)) + 0.16 * clamp(0, (0.25 - l) * 4, 1)) calc(c + 0.0181 * clamp(0, c * 200, 1)) calc(h + 6.6));
     display:flex;
     position:relative;
     flex-direction:column;

--- a/themes/kinder/assets/block.product.css
+++ b/themes/kinder/assets/block.product.css
@@ -2,10 +2,10 @@
 @layer snippets{
   [ui-block=product]{
     --bg-color:#fefefe;
-    --bg-shade-color:oklch(from var(--bg-color) calc(l - 0.018) c h);
+    --bg-shade-color:oklch(from var(--bg-color) calc(l - 0.018 * (1 - 2 * clamp(0, (0.5 - l) * 9999, 1))) c h);
     --fg-color:oklch(from var(--bg-color) clamp(0, calc((0.5 - l) * 9999), 1) 0 none);
     --quantity-bg:var(--bg-shade-color);
-    --shadow-color:oklch(from var(--bg-color) calc(l - 0.0225) calc(c + 0.0181) calc(h + 6.6));
+    --shadow-color:oklch(from var(--bg-color) calc(l - 0.0225 * (1 - 2 * clamp(0, (0.5 - l) * 9999, 1))) calc(c + 0.0181 * clamp(0, c * 200, 1)) calc(h + 6.6));
     display:flex;
     position:relative;
     flex-direction:column;

--- a/themes/kinder/assets/main.css
+++ b/themes/kinder/assets/main.css
@@ -299,7 +299,7 @@
     border-radius:var(--radius-button);
   }
   [ui-slot=button][data-variant=primary]:has([ui-slot=button-front]){
-    background-color:oklch(from var(--button-bg) calc(l - 0.08) c h);
+    background-color:oklch(from var(--button-bg) calc(l - 0.08 * (1 - 2 * clamp(0, (0.5 - l) * 9999, 1))) c h);
   }
   [ui-slot=button][data-variant=primary] [ui-slot=button-front]{
     display:flex;
@@ -359,7 +359,7 @@
     transform:translateY(-2px);
   }
   [ui-slot=button][data-variant=secondary]:has([ui-slot=button-front]){
-    background-color:oklch(from var(--button-bg) calc(l - 0.08) c h);
+    background-color:oklch(from var(--button-bg) calc(l - 0.08 * (1 - 2 * clamp(0, (0.5 - l) * 9999, 1))) c h);
   }
   [ui-slot=button][data-variant=neutral]{
     --button-bg:transparent;
@@ -519,7 +519,7 @@
     background-color:color-mix(in srgb, currentcolor 15%, transparent);
   }
   [ui-slot=divider]{
-    --color-divider:oklch(from var(--bg-color) calc(l - 0.05) c h);
+    --color-divider:oklch(from var(--bg-color) calc(l - 0.05 * (1 - 2 * clamp(0, (0.5 - l) * 9999, 1))) c h);
   }
   hr[ui-slot=divider][data-variant=line]{
     width:100%;

--- a/themes/kinder/assets/main.css
+++ b/themes/kinder/assets/main.css
@@ -299,7 +299,7 @@
     border-radius:var(--radius-button);
   }
   [ui-slot=button][data-variant=primary]:has([ui-slot=button-front]){
-    background-color:oklch(from var(--button-bg) calc(l - 0.08 * (1 - 2 * clamp(0, (0.5 - l) * 9999, 1))) c h);
+    background-color:oklch(from var(--button-bg) calc(l - 0.08 * (1 - 2 * clamp(0, (0.5 - l) * 9999, 1)) + 0.16 * clamp(0, (0.25 - l) * 4, 1)) c h);
   }
   [ui-slot=button][data-variant=primary] [ui-slot=button-front]{
     display:flex;
@@ -359,7 +359,7 @@
     transform:translateY(-2px);
   }
   [ui-slot=button][data-variant=secondary]:has([ui-slot=button-front]){
-    background-color:oklch(from var(--button-bg) calc(l - 0.08 * (1 - 2 * clamp(0, (0.5 - l) * 9999, 1))) c h);
+    background-color:oklch(from var(--button-bg) calc(l - 0.08 * (1 - 2 * clamp(0, (0.5 - l) * 9999, 1)) + 0.16 * clamp(0, (0.25 - l) * 4, 1)) c h);
   }
   [ui-slot=button][data-variant=neutral]{
     --button-bg:transparent;
@@ -519,7 +519,7 @@
     background-color:color-mix(in srgb, currentcolor 15%, transparent);
   }
   [ui-slot=divider]{
-    --color-divider:oklch(from var(--bg-color) calc(l - 0.05 * (1 - 2 * clamp(0, (0.5 - l) * 9999, 1))) c h);
+    --color-divider:oklch(from var(--bg-color) calc(l - 0.05 * (1 - 2 * clamp(0, (0.5 - l) * 9999, 1)) + 0.16 * clamp(0, (0.25 - l) * 4, 1)) c h);
   }
   hr[ui-slot=divider][data-variant=line]{
     width:100%;

--- a/themes/kinder/assets/misc.search.css
+++ b/themes/kinder/assets/misc.search.css
@@ -48,8 +48,8 @@
     border-radius:var(--radius-12);
   }
   #search[popover] [ui-slot=sheet-body] .products .items .item .media ui-image-fallback{
-    background-color:oklch(from var(--bg-color) calc(l - 0.018) c h);
-    color:oklch(from var(--fg-color) calc(l - 0.4) calc(c + 0.0181) calc(h + 6.6));
+    background-color:oklch(from var(--bg-color) calc(l - 0.018 * (1 - 2 * clamp(0, (0.5 - l) * 9999, 1))) c h);
+    color:oklch(from var(--fg-color) calc(l - 0.4 * (1 - 2 * clamp(0, (0.5 - l) * 9999, 1))) calc(c + 0.0181 * clamp(0, c * 200, 1)) calc(h + 6.6));
   }
   #search[popover] [ui-slot=sheet-body] .products .items .item .media > img{
     -o-object-fit:cover;
@@ -79,7 +79,7 @@
   #search[popover] [ui-slot=sheet-body] .products .items .item .content .categories .category{
     padding:var(--spacing-4) var(--spacing-8);
     border-radius:var(--radius-rounded);
-    background-color:oklch(from var(--bg-color) calc(l - 0.018) c h);
+    background-color:oklch(from var(--bg-color) calc(l - 0.018 * (1 - 2 * clamp(0, (0.5 - l) * 9999, 1))) c h);
     font:var(--font-label-xs);
     text-align:center;
   }

--- a/themes/kinder/assets/misc.search.css
+++ b/themes/kinder/assets/misc.search.css
@@ -48,8 +48,8 @@
     border-radius:var(--radius-12);
   }
   #search[popover] [ui-slot=sheet-body] .products .items .item .media ui-image-fallback{
-    background-color:oklch(from var(--bg-color) calc(l - 0.018 * (1 - 2 * clamp(0, (0.5 - l) * 9999, 1))) c h);
-    color:oklch(from var(--fg-color) calc(l - 0.4 * (1 - 2 * clamp(0, (0.5 - l) * 9999, 1))) calc(c + 0.0181 * clamp(0, c * 200, 1)) calc(h + 6.6));
+    background-color:oklch(from var(--bg-color) calc(l - 0.018 * (1 - 2 * clamp(0, (0.5 - l) * 9999, 1)) + 0.16 * clamp(0, (0.25 - l) * 4, 1)) c h);
+    color:oklch(from var(--fg-color) calc(l - 0.4 * (1 - 2 * clamp(0, (0.5 - l) * 9999, 1)) + 0.16 * clamp(0, (0.25 - l) * 4, 1)) calc(c + 0.0181 * clamp(0, c * 200, 1)) calc(h + 6.6));
   }
   #search[popover] [ui-slot=sheet-body] .products .items .item .media > img{
     -o-object-fit:cover;
@@ -79,7 +79,7 @@
   #search[popover] [ui-slot=sheet-body] .products .items .item .content .categories .category{
     padding:var(--spacing-4) var(--spacing-8);
     border-radius:var(--radius-rounded);
-    background-color:oklch(from var(--bg-color) calc(l - 0.018 * (1 - 2 * clamp(0, (0.5 - l) * 9999, 1))) c h);
+    background-color:oklch(from var(--bg-color) calc(l - 0.018 * (1 - 2 * clamp(0, (0.5 - l) * 9999, 1)) + 0.16 * clamp(0, (0.25 - l) * 4, 1)) c h);
     font:var(--font-label-xs);
     text-align:center;
   }

--- a/themes/kinder/assets/misc.toast.css
+++ b/themes/kinder/assets/misc.toast.css
@@ -2,7 +2,7 @@
 @layer snippets{
   ui-toast{
     --bg-color:#fefefe;
-    --bg-shade-color:oklch(from var(--bg-color) calc(l - 0.018 * (1 - 2 * clamp(0, (0.5 - l) * 9999, 1))) c h);
+    --bg-shade-color:oklch(from var(--bg-color) calc(l - 0.018 * (1 - 2 * clamp(0, (0.5 - l) * 9999, 1)) + 0.16 * clamp(0, (0.25 - l) * 4, 1)) c h);
     --fg-color:oklch(from var(--bg-color) clamp(0, calc((0.5 - l) * 9999), 1) 0 none);
     inset:auto;
     display:flex;

--- a/themes/kinder/assets/misc.toast.css
+++ b/themes/kinder/assets/misc.toast.css
@@ -2,7 +2,7 @@
 @layer snippets{
   ui-toast{
     --bg-color:#fefefe;
-    --bg-shade-color:oklch(from var(--bg-color) calc(l - 0.018) c h);
+    --bg-shade-color:oklch(from var(--bg-color) calc(l - 0.018 * (1 - 2 * clamp(0, (0.5 - l) * 9999, 1))) c h);
     --fg-color:oklch(from var(--bg-color) clamp(0, calc((0.5 - l) * 9999), 1) 0 none);
     inset:auto;
     display:flex;

--- a/themes/kinder/assets/section.cart.css
+++ b/themes/kinder/assets/section.cart.css
@@ -1,6 +1,6 @@
 @layer sections{
   [ui-section=cart]{
-    --bg-shade-color:oklch(from var(--bg-color) calc(l - 0.0225) calc(c + 0.0181) calc(h + 6.6));
+    --bg-shade-color:oklch(from var(--bg-color) calc(l - 0.0225 * (1 - 2 * clamp(0, (0.5 - l) * 9999, 1))) calc(c + 0.0181 * clamp(0, c * 200, 1)) calc(h + 6.6));
     display:flex;
     gap:var(--spacing-48);
     flex-direction:column;
@@ -151,7 +151,7 @@
     gap:var(--spacing-8);
   }
   [ui-section=cart] .core-area .summary .coupon .output .info [ui-slot=status-badge]{
-    background-color:oklch(from var(--bg-shade-color) calc(l - 0.0444) calc(c + 0.0456) calc(h - 1));
+    background-color:oklch(from var(--bg-shade-color) calc(l - 0.0444 * (1 - 2 * clamp(0, (0.5 - l) * 9999, 1))) calc(c + 0.0456 * clamp(0, c * 200, 1)) calc(h - 1));
     color:var(--fg-color);
     font:var(--font-label-sm);
   }

--- a/themes/kinder/assets/section.cart.css
+++ b/themes/kinder/assets/section.cart.css
@@ -1,6 +1,6 @@
 @layer sections{
   [ui-section=cart]{
-    --bg-shade-color:oklch(from var(--bg-color) calc(l - 0.0225 * (1 - 2 * clamp(0, (0.5 - l) * 9999, 1))) calc(c + 0.0181 * clamp(0, c * 200, 1)) calc(h + 6.6));
+    --bg-shade-color:oklch(from var(--bg-color) calc(l - 0.0225 * (1 - 2 * clamp(0, (0.5 - l) * 9999, 1)) + 0.16 * clamp(0, (0.25 - l) * 4, 1)) calc(c + 0.0181 * clamp(0, c * 200, 1)) calc(h + 6.6));
     display:flex;
     gap:var(--spacing-48);
     flex-direction:column;
@@ -151,7 +151,7 @@
     gap:var(--spacing-8);
   }
   [ui-section=cart] .core-area .summary .coupon .output .info [ui-slot=status-badge]{
-    background-color:oklch(from var(--bg-shade-color) calc(l - 0.0444 * (1 - 2 * clamp(0, (0.5 - l) * 9999, 1))) calc(c + 0.0456 * clamp(0, c * 200, 1)) calc(h - 1));
+    background-color:oklch(from var(--bg-shade-color) calc(l - 0.0444 * (1 - 2 * clamp(0, (0.5 - l) * 9999, 1)) + 0.16 * clamp(0, (0.25 - l) * 4, 1)) calc(c + 0.0456 * clamp(0, c * 200, 1)) calc(h - 1));
     color:var(--fg-color);
     font:var(--font-label-sm);
   }

--- a/themes/kinder/assets/section.collection-tabs.css
+++ b/themes/kinder/assets/section.collection-tabs.css
@@ -18,7 +18,7 @@
     height:fit-content;
     padding:var(--spacing-24);
     border-radius:var(--radius-card);
-    background-color:oklch(from var(--bg-color) calc(l - 0.0225) calc(c + 0.0181) calc(h + 6.6));
+    background-color:oklch(from var(--bg-color) calc(l - 0.0225 * (1 - 2 * clamp(0, (0.5 - l) * 9999, 1))) calc(c + 0.0181 * clamp(0, c * 200, 1)) calc(h + 6.6));
     inset-block-start:var(--spacing-16);
     gap:var(--spacing-40);
   }
@@ -129,7 +129,7 @@
 }
 @layer snippets{
   [ui-block=product-tab]{
-    --bg-shade-color:oklch(from var(--bg-color) calc(l - 0.0225) calc(c + 0.0181) calc(h + 6.6));
+    --bg-shade-color:oklch(from var(--bg-color) calc(l - 0.0225 * (1 - 2 * clamp(0, (0.5 - l) * 9999, 1))) calc(c + 0.0181 * clamp(0, c * 200, 1)) calc(h + 6.6));
     display:flex;
     gap:var(--spacing-16);
     flex-direction:column;

--- a/themes/kinder/assets/section.collection-tabs.css
+++ b/themes/kinder/assets/section.collection-tabs.css
@@ -18,7 +18,7 @@
     height:fit-content;
     padding:var(--spacing-24);
     border-radius:var(--radius-card);
-    background-color:oklch(from var(--bg-color) calc(l - 0.0225 * (1 - 2 * clamp(0, (0.5 - l) * 9999, 1))) calc(c + 0.0181 * clamp(0, c * 200, 1)) calc(h + 6.6));
+    background-color:oklch(from var(--bg-color) calc(l - 0.0225 * (1 - 2 * clamp(0, (0.5 - l) * 9999, 1)) + 0.16 * clamp(0, (0.25 - l) * 4, 1)) calc(c + 0.0181 * clamp(0, c * 200, 1)) calc(h + 6.6));
     inset-block-start:var(--spacing-16);
     gap:var(--spacing-40);
   }
@@ -129,7 +129,7 @@
 }
 @layer snippets{
   [ui-block=product-tab]{
-    --bg-shade-color:oklch(from var(--bg-color) calc(l - 0.0225 * (1 - 2 * clamp(0, (0.5 - l) * 9999, 1))) calc(c + 0.0181 * clamp(0, c * 200, 1)) calc(h + 6.6));
+    --bg-shade-color:oklch(from var(--bg-color) calc(l - 0.0225 * (1 - 2 * clamp(0, (0.5 - l) * 9999, 1)) + 0.16 * clamp(0, (0.25 - l) * 4, 1)) calc(c + 0.0181 * clamp(0, c * 200, 1)) calc(h + 6.6));
     display:flex;
     gap:var(--spacing-16);
     flex-direction:column;

--- a/themes/kinder/assets/section.countdown-timer.css
+++ b/themes/kinder/assets/section.countdown-timer.css
@@ -55,7 +55,7 @@
     height:var(--segment-size);
     padding:var(--spacing-16);
     border-radius:var(--radius-16);
-    background-color:oklch(from var(--timer-bg) calc(l - 0.058 * (1 - 2 * clamp(0, (0.5 - l) * 9999, 1))) calc(c + 0.03 * clamp(0, c * 200, 1)) h);
+    background-color:oklch(from var(--timer-bg) calc(l - 0.058 * (1 - 2 * clamp(0, (0.5 - l) * 9999, 1)) + 0.16 * clamp(0, (0.25 - l) * 4, 1)) calc(c + 0.03 * clamp(0, c * 200, 1)) h);
     font:var(--font-heading-lg);
   }
   [ui-section=countdown-timer] .timer-container .timer .label,

--- a/themes/kinder/assets/section.countdown-timer.css
+++ b/themes/kinder/assets/section.countdown-timer.css
@@ -55,7 +55,7 @@
     height:var(--segment-size);
     padding:var(--spacing-16);
     border-radius:var(--radius-16);
-    background-color:oklch(from var(--timer-bg) calc(l - 0.058) calc(c + 0.03) h);
+    background-color:oklch(from var(--timer-bg) calc(l - 0.058 * (1 - 2 * clamp(0, (0.5 - l) * 9999, 1))) calc(c + 0.03 * clamp(0, c * 200, 1)) h);
     font:var(--font-heading-lg);
   }
   [ui-section=countdown-timer] .timer-container .timer .label,

--- a/themes/kinder/assets/section.faqs.css
+++ b/themes/kinder/assets/section.faqs.css
@@ -20,7 +20,7 @@
     width:400px;
     overflow:hidden;
     border-radius:calc(var(--radius-card) / 2);
-    background-color:oklch(from var(--inner-bg-color) calc(l - 0.0225) c h);
+    background-color:oklch(from var(--inner-bg-color) calc(l - 0.0225 * (1 - 2 * clamp(0, (0.5 - l) * 9999, 1))) c h);
   }
   [ui-section=faqs] .faqs-card .content .media[data-image-ratio=square]{
     aspect-ratio:1/1;

--- a/themes/kinder/assets/section.faqs.css
+++ b/themes/kinder/assets/section.faqs.css
@@ -20,7 +20,7 @@
     width:400px;
     overflow:hidden;
     border-radius:calc(var(--radius-card) / 2);
-    background-color:oklch(from var(--inner-bg-color) calc(l - 0.0225 * (1 - 2 * clamp(0, (0.5 - l) * 9999, 1))) c h);
+    background-color:oklch(from var(--inner-bg-color) calc(l - 0.0225 * (1 - 2 * clamp(0, (0.5 - l) * 9999, 1)) + 0.16 * clamp(0, (0.25 - l) * 4, 1)) c h);
   }
   [ui-section=faqs] .faqs-card .content .media[data-image-ratio=square]{
     aspect-ratio:1/1;

--- a/themes/kinder/assets/section.featured-collection.css
+++ b/themes/kinder/assets/section.featured-collection.css
@@ -10,7 +10,7 @@
     height:640px;
     overflow:hidden;
     border-radius:var(--radius-card);
-    background-color:oklch(from var(--bg-color) calc(l - 0.0225 * (1 - 2 * clamp(0, (0.5 - l) * 9999, 1))) calc(c + 0.0181 * clamp(0, c * 200, 1)) calc(h + 6.6));
+    background-color:oklch(from var(--bg-color) calc(l - 0.0225 * (1 - 2 * clamp(0, (0.5 - l) * 9999, 1)) + 0.16 * clamp(0, (0.25 - l) * 4, 1)) calc(c + 0.0181 * clamp(0, c * 200, 1)) calc(h + 6.6));
     inset-block-start:var(--spacing-16);
   }
   [ui-section=featured-collection] .banner[data-banner-placement=first]{

--- a/themes/kinder/assets/section.featured-collection.css
+++ b/themes/kinder/assets/section.featured-collection.css
@@ -10,7 +10,7 @@
     height:640px;
     overflow:hidden;
     border-radius:var(--radius-card);
-    background-color:oklch(from var(--bg-color) calc(l - 0.0225) calc(c + 0.0181) calc(h + 6.6));
+    background-color:oklch(from var(--bg-color) calc(l - 0.0225 * (1 - 2 * clamp(0, (0.5 - l) * 9999, 1))) calc(c + 0.0181 * clamp(0, c * 200, 1)) calc(h + 6.6));
     inset-block-start:var(--spacing-16);
   }
   [ui-section=featured-collection] .banner[data-banner-placement=first]{

--- a/themes/kinder/assets/section.footer.css
+++ b/themes/kinder/assets/section.footer.css
@@ -55,7 +55,7 @@
     gap:var(--spacing-48);
     padding:var(--card-spacing);
     border-radius:var(--card-radius);
-    background-color:oklch(from var(--bg-color) calc(l - 0.0225 * (1 - 2 * clamp(0, (0.5 - l) * 9999, 1))) calc(c + 0.0181 * clamp(0, c * 200, 1)) calc(h + 6.6));
+    background-color:oklch(from var(--bg-color) calc(l - 0.0225 * (1 - 2 * clamp(0, (0.5 - l) * 9999, 1)) + 0.16 * clamp(0, (0.25 - l) * 4, 1)) calc(c + 0.0181 * clamp(0, c * 200, 1)) calc(h + 6.6));
   }
   [ui-layout=footer] .menu .groups{
     display:flex;

--- a/themes/kinder/assets/section.footer.css
+++ b/themes/kinder/assets/section.footer.css
@@ -55,7 +55,7 @@
     gap:var(--spacing-48);
     padding:var(--card-spacing);
     border-radius:var(--card-radius);
-    background-color:oklch(from var(--bg-color) calc(l - 0.0225) calc(c + 0.0181) calc(h + 6.6));
+    background-color:oklch(from var(--bg-color) calc(l - 0.0225 * (1 - 2 * clamp(0, (0.5 - l) * 9999, 1))) calc(c + 0.0181 * clamp(0, c * 200, 1)) calc(h + 6.6));
   }
   [ui-layout=footer] .menu .groups{
     display:flex;

--- a/themes/kinder/assets/section.header.css
+++ b/themes/kinder/assets/section.header.css
@@ -147,7 +147,7 @@
     padding:var(--spacing-16);
     padding-block-end:var(--spacing-8);
     border-radius:var(--radius-8);
-    background-color:oklch(from var(--bg-color) calc(l - 0.02) c h);
+    background-color:oklch(from var(--bg-color) calc(l - 0.02 * (1 - 2 * clamp(0, (0.5 - l) * 9999, 1))) c h);
     grid-gap:var(--spacing-8);
     gap:var(--spacing-8);
   }

--- a/themes/kinder/assets/section.header.css
+++ b/themes/kinder/assets/section.header.css
@@ -147,7 +147,7 @@
     padding:var(--spacing-16);
     padding-block-end:var(--spacing-8);
     border-radius:var(--radius-8);
-    background-color:oklch(from var(--bg-color) calc(l - 0.02 * (1 - 2 * clamp(0, (0.5 - l) * 9999, 1))) c h);
+    background-color:oklch(from var(--bg-color) calc(l - 0.02 * (1 - 2 * clamp(0, (0.5 - l) * 9999, 1)) + 0.16 * clamp(0, (0.25 - l) * 4, 1)) c h);
     grid-gap:var(--spacing-8);
     gap:var(--spacing-8);
   }

--- a/themes/kinder/assets/section.image-banners.css
+++ b/themes/kinder/assets/section.image-banners.css
@@ -14,14 +14,14 @@
     padding:var(--spacing-32);
     overflow:hidden;
     border-radius:var(--radius-card);
-    background-color:oklch(from var(--bg-color) calc(l - 0.0225 * (1 - 2 * clamp(0, (0.5 - l) * 9999, 1))) calc(c + 0.0181 * clamp(0, c * 200, 1)) calc(h + 6.6));
+    background-color:oklch(from var(--bg-color) calc(l - 0.0225 * (1 - 2 * clamp(0, (0.5 - l) * 9999, 1)) + 0.16 * clamp(0, (0.25 - l) * 4, 1)) calc(c + 0.0181 * clamp(0, c * 200, 1)) calc(h + 6.6));
   }
   [ui-section=image-banners] .banners .image-item [ui-block=image]{
     position:absolute;
     inset:0;
   }
   [ui-section=image-banners] .banners .image-item [ui-block=image] ui-image-fallback{
-    color:oklch(from var(--bg-color) calc(l - 0.4 * (1 - 2 * clamp(0, (0.5 - l) * 9999, 1))) calc(c + 0.0181 * clamp(0, c * 200, 1)) calc(h + 6.6));
+    color:oklch(from var(--bg-color) calc(l - 0.4 * (1 - 2 * clamp(0, (0.5 - l) * 9999, 1)) + 0.16 * clamp(0, (0.25 - l) * 4, 1)) calc(c + 0.0181 * clamp(0, c * 200, 1)) calc(h + 6.6));
   }
   [ui-section=image-banners] .banners .image-item [ui-block=image] img{
     -o-object-fit:cover;

--- a/themes/kinder/assets/section.image-banners.css
+++ b/themes/kinder/assets/section.image-banners.css
@@ -14,14 +14,14 @@
     padding:var(--spacing-32);
     overflow:hidden;
     border-radius:var(--radius-card);
-    background-color:oklch(from var(--bg-color) calc(l - 0.0225) calc(c + 0.0181) calc(h + 6.6));
+    background-color:oklch(from var(--bg-color) calc(l - 0.0225 * (1 - 2 * clamp(0, (0.5 - l) * 9999, 1))) calc(c + 0.0181 * clamp(0, c * 200, 1)) calc(h + 6.6));
   }
   [ui-section=image-banners] .banners .image-item [ui-block=image]{
     position:absolute;
     inset:0;
   }
   [ui-section=image-banners] .banners .image-item [ui-block=image] ui-image-fallback{
-    color:oklch(from var(--bg-color) calc(l - 0.4) calc(c + 0.0181) calc(h + 6.6));
+    color:oklch(from var(--bg-color) calc(l - 0.4 * (1 - 2 * clamp(0, (0.5 - l) * 9999, 1))) calc(c + 0.0181 * clamp(0, c * 200, 1)) calc(h + 6.6));
   }
   [ui-section=image-banners] .banners .image-item [ui-block=image] img{
     -o-object-fit:cover;

--- a/themes/kinder/assets/section.image-with-text.css
+++ b/themes/kinder/assets/section.image-with-text.css
@@ -1,6 +1,6 @@
 @layer sections{
   [ui-section=image-with-text] .wrapper-area{
-    --bg-shade-color:oklch(from var(--bg-color) calc(l - 0.0225) calc(c + 0.0181) calc(h + 6.6));
+    --bg-shade-color:oklch(from var(--bg-color) calc(l - 0.0225 * (1 - 2 * clamp(0, (0.5 - l) * 9999, 1))) calc(c + 0.0181 * clamp(0, c * 200, 1)) calc(h + 6.6));
     display:grid;
     grid-template-columns:repeat(2, 1fr);
     height:var(--height);
@@ -16,7 +16,7 @@
   [ui-section=image-with-text] .wrapper-area [ui-block=media]{
     height:inherit;
     overflow:hidden;
-    color:oklch(from var(--fg-color) calc(l - 0.4) calc(c + 0.0181) calc(h + 6.6));
+    color:oklch(from var(--fg-color) calc(l - 0.4 * (1 - 2 * clamp(0, (0.5 - l) * 9999, 1))) calc(c + 0.0181 * clamp(0, c * 200, 1)) calc(h + 6.6));
   }
   [ui-section=image-with-text] .wrapper-area [ui-block=media] > img{
     -o-object-fit:cover;

--- a/themes/kinder/assets/section.image-with-text.css
+++ b/themes/kinder/assets/section.image-with-text.css
@@ -1,6 +1,6 @@
 @layer sections{
   [ui-section=image-with-text] .wrapper-area{
-    --bg-shade-color:oklch(from var(--bg-color) calc(l - 0.0225 * (1 - 2 * clamp(0, (0.5 - l) * 9999, 1))) calc(c + 0.0181 * clamp(0, c * 200, 1)) calc(h + 6.6));
+    --bg-shade-color:oklch(from var(--bg-color) calc(l - 0.0225 * (1 - 2 * clamp(0, (0.5 - l) * 9999, 1)) + 0.16 * clamp(0, (0.25 - l) * 4, 1)) calc(c + 0.0181 * clamp(0, c * 200, 1)) calc(h + 6.6));
     display:grid;
     grid-template-columns:repeat(2, 1fr);
     height:var(--height);
@@ -16,7 +16,7 @@
   [ui-section=image-with-text] .wrapper-area [ui-block=media]{
     height:inherit;
     overflow:hidden;
-    color:oklch(from var(--fg-color) calc(l - 0.4 * (1 - 2 * clamp(0, (0.5 - l) * 9999, 1))) calc(c + 0.0181 * clamp(0, c * 200, 1)) calc(h + 6.6));
+    color:oklch(from var(--fg-color) calc(l - 0.4 * (1 - 2 * clamp(0, (0.5 - l) * 9999, 1)) + 0.16 * clamp(0, (0.25 - l) * 4, 1)) calc(c + 0.0181 * clamp(0, c * 200, 1)) calc(h + 6.6));
   }
   [ui-section=image-with-text] .wrapper-area [ui-block=media] > img{
     -o-object-fit:cover;

--- a/themes/kinder/assets/section.page.css
+++ b/themes/kinder/assets/section.page.css
@@ -1,6 +1,6 @@
 @layer sections{
   [ui-section=page]{
-    --bg-shade-color:oklch(from var(--bg-color) calc(l - 0.0225 * (1 - 2 * clamp(0, (0.5 - l) * 9999, 1))) calc(c + 0.0181 * clamp(0, c * 200, 1)) calc(h + 6.6));
+    --bg-shade-color:oklch(from var(--bg-color) calc(l - 0.0225 * (1 - 2 * clamp(0, (0.5 - l) * 9999, 1)) + 0.16 * clamp(0, (0.25 - l) * 4, 1)) calc(c + 0.0181 * clamp(0, c * 200, 1)) calc(h + 6.6));
     display:flex;
     flex-direction:column;
     gap:var(--spacing-24);

--- a/themes/kinder/assets/section.page.css
+++ b/themes/kinder/assets/section.page.css
@@ -1,6 +1,6 @@
 @layer sections{
   [ui-section=page]{
-    --bg-shade-color:oklch(from var(--bg-color) calc(l - 0.0225) calc(c + 0.0181) calc(h + 6.6));
+    --bg-shade-color:oklch(from var(--bg-color) calc(l - 0.0225 * (1 - 2 * clamp(0, (0.5 - l) * 9999, 1))) calc(c + 0.0181 * clamp(0, c * 200, 1)) calc(h + 6.6));
     display:flex;
     flex-direction:column;
     gap:var(--spacing-24);

--- a/themes/kinder/assets/section.product-information.css
+++ b/themes/kinder/assets/section.product-information.css
@@ -1,7 +1,7 @@
 @layer sections{
   [ui-section=product-information]{
-    --bg-shade-color:oklch(from var(--bg-color) calc(l - 0.0225) calc(c + 0.0181) calc(h + 6.6));
-    --bg-on-shade-color:oklch(from var(--bg-shade-color) calc(l - 0.02) calc(c + 0.005) calc(h + 1)) !important;
+    --bg-shade-color:oklch(from var(--bg-color) calc(l - 0.0225 * (1 - 2 * clamp(0, (0.5 - l) * 9999, 1))) calc(c + 0.0181 * clamp(0, c * 200, 1)) calc(h + 6.6));
+    --bg-on-shade-color:oklch(from var(--bg-shade-color) calc(l - 0.02 * (1 - 2 * clamp(0, (0.5 - l) * 9999, 1))) calc(c + 0.005 * clamp(0, c * 200, 1)) calc(h + 1)) !important;
     display:flex;
     gap:var(--spacing-24);
     flex-direction:column;

--- a/themes/kinder/assets/section.product-information.css
+++ b/themes/kinder/assets/section.product-information.css
@@ -1,7 +1,7 @@
 @layer sections{
   [ui-section=product-information]{
-    --bg-shade-color:oklch(from var(--bg-color) calc(l - 0.0225 * (1 - 2 * clamp(0, (0.5 - l) * 9999, 1))) calc(c + 0.0181 * clamp(0, c * 200, 1)) calc(h + 6.6));
-    --bg-on-shade-color:oklch(from var(--bg-shade-color) calc(l - 0.02 * (1 - 2 * clamp(0, (0.5 - l) * 9999, 1))) calc(c + 0.005 * clamp(0, c * 200, 1)) calc(h + 1)) !important;
+    --bg-shade-color:oklch(from var(--bg-color) calc(l - 0.0225 * (1 - 2 * clamp(0, (0.5 - l) * 9999, 1)) + 0.16 * clamp(0, (0.25 - l) * 4, 1)) calc(c + 0.0181 * clamp(0, c * 200, 1)) calc(h + 6.6));
+    --bg-on-shade-color:oklch(from var(--bg-shade-color) calc(l - 0.02 * (1 - 2 * clamp(0, (0.5 - l) * 9999, 1)) + 0.16 * clamp(0, (0.25 - l) * 4, 1)) calc(c + 0.005 * clamp(0, c * 200, 1)) calc(h + 1)) !important;
     display:flex;
     gap:var(--spacing-24);
     flex-direction:column;

--- a/themes/kinder/assets/section.reviews.css
+++ b/themes/kinder/assets/section.reviews.css
@@ -1,7 +1,7 @@
 @layer sections{
   [ui-section=reviews]{
     --star-color:#f7ca4d;
-    --bg-shade-color:oklch(from var(--bg-color) calc(l - 0.0225 * (1 - 2 * clamp(0, (0.5 - l) * 9999, 1))) calc(c + 0.0181 * clamp(0, c * 200, 1)) calc(h + 6.6));
+    --bg-shade-color:oklch(from var(--bg-color) calc(l - 0.0225 * (1 - 2 * clamp(0, (0.5 - l) * 9999, 1)) + 0.16 * clamp(0, (0.25 - l) * 4, 1)) calc(c + 0.0181 * clamp(0, c * 200, 1)) calc(h + 6.6));
     display:grid;
     grid-template-columns:55% auto;
     grid-gap:var(--spacing-64);

--- a/themes/kinder/assets/section.reviews.css
+++ b/themes/kinder/assets/section.reviews.css
@@ -1,7 +1,7 @@
 @layer sections{
   [ui-section=reviews]{
     --star-color:#f7ca4d;
-    --bg-shade-color:oklch(from var(--bg-color) calc(l - 0.0225) calc(c + 0.0181) calc(h + 6.6));
+    --bg-shade-color:oklch(from var(--bg-color) calc(l - 0.0225 * (1 - 2 * clamp(0, (0.5 - l) * 9999, 1))) calc(c + 0.0181 * clamp(0, c * 200, 1)) calc(h + 6.6));
     display:grid;
     grid-template-columns:55% auto;
     grid-gap:var(--spacing-64);

--- a/themes/kinder/assets/section.search.css
+++ b/themes/kinder/assets/section.search.css
@@ -1,6 +1,6 @@
 @layer sections{
   [ui-section=search]{
-    --bg-shade-color:oklch(from var(--bg-color) calc(l - 0.0225) calc(c + 0.0181) calc(h + 6.6));
+    --bg-shade-color:oklch(from var(--bg-color) calc(l - 0.0225 * (1 - 2 * clamp(0, (0.5 - l) * 9999, 1))) calc(c + 0.0181 * clamp(0, c * 200, 1)) calc(h + 6.6));
     display:flex;
     flex:1;
     flex-direction:column;

--- a/themes/kinder/assets/section.search.css
+++ b/themes/kinder/assets/section.search.css
@@ -1,6 +1,6 @@
 @layer sections{
   [ui-section=search]{
-    --bg-shade-color:oklch(from var(--bg-color) calc(l - 0.0225 * (1 - 2 * clamp(0, (0.5 - l) * 9999, 1))) calc(c + 0.0181 * clamp(0, c * 200, 1)) calc(h + 6.6));
+    --bg-shade-color:oklch(from var(--bg-color) calc(l - 0.0225 * (1 - 2 * clamp(0, (0.5 - l) * 9999, 1)) + 0.16 * clamp(0, (0.25 - l) * 4, 1)) calc(c + 0.0181 * clamp(0, c * 200, 1)) calc(h + 6.6));
     display:flex;
     flex:1;
     flex-direction:column;

--- a/themes/kinder/assets/section.single-collection.css
+++ b/themes/kinder/assets/section.single-collection.css
@@ -1,6 +1,6 @@
 @layer sections{
   [ui-section=single-collection]{
-    --bg-shade-color:oklch(from var(--bg-color) calc(l - 0.0225 * (1 - 2 * clamp(0, (0.5 - l) * 9999, 1))) calc(c + 0.0181 * clamp(0, c * 200, 1)) calc(h + 6.6));
+    --bg-shade-color:oklch(from var(--bg-color) calc(l - 0.0225 * (1 - 2 * clamp(0, (0.5 - l) * 9999, 1)) + 0.16 * clamp(0, (0.25 - l) * 4, 1)) calc(c + 0.0181 * clamp(0, c * 200, 1)) calc(h + 6.6));
     display:flex;
     gap:var(--spacing-48);
     flex-direction:column;

--- a/themes/kinder/assets/section.single-collection.css
+++ b/themes/kinder/assets/section.single-collection.css
@@ -1,6 +1,6 @@
 @layer sections{
   [ui-section=single-collection]{
-    --bg-shade-color:oklch(from var(--bg-color) calc(l - 0.0225) calc(c + 0.0181) calc(h + 6.6));
+    --bg-shade-color:oklch(from var(--bg-color) calc(l - 0.0225 * (1 - 2 * clamp(0, (0.5 - l) * 9999, 1))) calc(c + 0.0181 * clamp(0, c * 200, 1)) calc(h + 6.6));
     display:flex;
     gap:var(--spacing-48);
     flex-direction:column;

--- a/themes/kinder/assets/section.thankyou.css
+++ b/themes/kinder/assets/section.thankyou.css
@@ -1,6 +1,6 @@
 @layer sections{
   [ui-section=thankyou]{
-    --bg-shade-color:oklch(from var(--bg-color) calc(l - 0.0225) calc(c + 0.0181) calc(h + 6.6));
+    --bg-shade-color:oklch(from var(--bg-color) calc(l - 0.0225 * (1 - 2 * clamp(0, (0.5 - l) * 9999, 1))) calc(c + 0.0181 * clamp(0, c * 200, 1)) calc(h + 6.6));
     display:grid;
     grid-template-columns:1fr minmax(0, 460px);
     grid-gap:var(--spacing-64);

--- a/themes/kinder/assets/section.thankyou.css
+++ b/themes/kinder/assets/section.thankyou.css
@@ -1,6 +1,6 @@
 @layer sections{
   [ui-section=thankyou]{
-    --bg-shade-color:oklch(from var(--bg-color) calc(l - 0.0225 * (1 - 2 * clamp(0, (0.5 - l) * 9999, 1))) calc(c + 0.0181 * clamp(0, c * 200, 1)) calc(h + 6.6));
+    --bg-shade-color:oklch(from var(--bg-color) calc(l - 0.0225 * (1 - 2 * clamp(0, (0.5 - l) * 9999, 1)) + 0.16 * clamp(0, (0.25 - l) * 4, 1)) calc(c + 0.0181 * clamp(0, c * 200, 1)) calc(h + 6.6));
     display:grid;
     grid-template-columns:1fr minmax(0, 460px);
     grid-gap:var(--spacing-64);

--- a/themes/kinder/assets/section.upsell.css
+++ b/themes/kinder/assets/section.upsell.css
@@ -1,6 +1,6 @@
 @layer sections{
   ui-upsell{
-    --bg-shade-color:oklch(from var(--bg-color) calc(l - 0.0225 * (1 - 2 * clamp(0, (0.5 - l) * 9999, 1))) calc(c + 0.0181 * clamp(0, c * 200, 1)) calc(h + 6.6));
+    --bg-shade-color:oklch(from var(--bg-color) calc(l - 0.0225 * (1 - 2 * clamp(0, (0.5 - l) * 9999, 1)) + 0.16 * clamp(0, (0.25 - l) * 4, 1)) calc(c + 0.0181 * clamp(0, c * 200, 1)) calc(h + 6.6));
     display:grid;
     grid-template-columns:1fr 2fr;
     flex:1;

--- a/themes/kinder/assets/section.upsell.css
+++ b/themes/kinder/assets/section.upsell.css
@@ -1,6 +1,6 @@
 @layer sections{
   ui-upsell{
-    --bg-shade-color:oklch(from var(--bg-color) calc(l - 0.0225) calc(c + 0.0181) calc(h + 6.6));
+    --bg-shade-color:oklch(from var(--bg-color) calc(l - 0.0225 * (1 - 2 * clamp(0, (0.5 - l) * 9999, 1))) calc(c + 0.0181 * clamp(0, c * 200, 1)) calc(h + 6.6));
     display:grid;
     grid-template-columns:1fr 2fr;
     flex:1;

--- a/themes/kinder/styles/_color.scss
+++ b/themes/kinder/styles/_color.scss
@@ -1,3 +1,4 @@
+@use "sass:math";
 @use "sass:string";
 
 /* Emits a channel term, omitting the calc() when the delta is a no-op. */
@@ -13,65 +14,88 @@
   @return "calc(#{$channel} + #{$delta})";
 }
 
-/* Emits the lightness term, flipping its direction on a dark origin. */
-@function _lightness($delta, $pivot) {
-  @if $delta == 0 {
+/* Emits the lightness term: flips direction on a dark origin, then lifts the
+   step further the closer the origin sits to black. */
+@function _lightness($delta, $lighten-below, $lift, $lift-below) {
+  $flip: "(1 - 2 * clamp(0, (#{$lighten-below} - l) * 9999, 1))";
+  $ramp: "clamp(0, (#{$lift-below} - l) * #{math.div(1, $lift-below)}, 1)";
+  $step: "l";
+
+  @if $delta < 0 {
+    $step: "l - #{-1 * $delta} * #{$flip}";
+  }
+
+  @if $delta > 0 {
+    $step: "l + #{$delta} * #{$flip}";
+  }
+
+  @if $lift == 0 and $delta == 0 {
     @return "l";
   }
 
-  $flip: "(1 - 2 * clamp(0, (#{$pivot} - l) * 9999, 1))";
-
-  @if $delta < 0 {
-    @return "calc(l - #{-1 * $delta} * #{$flip})";
+  @if $lift == 0 {
+    @return "calc(#{$step})";
   }
 
-  @return "calc(l + #{$delta} * #{$flip})";
+  @return "calc(#{$step} + #{$lift} * #{$ramp})";
 }
 
 /* Emits the chroma term, scaled by how chromatic the origin already is. */
-@function _chroma($delta, $gate) {
+@function _chroma($delta, $tint-above) {
   @if $delta == 0 {
     @return "c";
   }
 
+  $ramp: "clamp(0, c * #{math.div(1, $tint-above)}, 1)";
+
   @if $delta < 0 {
-    @return "calc(c - #{-1 * $delta} * clamp(0, c * #{$gate}, 1))";
+    @return "calc(c - #{-1 * $delta} * #{$ramp})";
   }
 
-  @return "calc(c + #{$delta} * clamp(0, c * #{$gate}, 1))";
+  @return "calc(c + #{$delta} * #{$ramp})";
 }
 
 /* Derives a shade from an origin color in OKLCH.
 
-   $from   origin color, e.g. var(--bg-color)
-   $l      lightness delta, expressed for a light origin and mirrored on a dark one
-   $c      chroma delta, reached in full once the origin's own chroma is 1 / $gate
-   $h      hue rotation, in degrees
-   $gate   inverse of the chroma at which $c applies in full
-   $pivot  lightness below which the origin counts as dark
+   $from           origin color, e.g. var(--bg-color)
+   $l              lightness delta, written for a light origin and mirrored on a dark one
+   $c              chroma delta, applied in full once the origin is at least $tint-above
+   $h              hue rotation, in degrees
+   $tint-above     chroma at which $c reaches full strength
+   $lighten-below  lightness under which the origin counts as dark and $l lightens instead
+   $lift           extra lightness added to the step on a pure black origin
+   $lift-below     lightness at which $lift has tapered back to nothing
 
-   The chroma delta is scaled by clamp(0, c * $gate, 1), which is 0 for an
-   achromatic origin and 1 once it is chromatic. Adding chroma unconditionally
-   tints greys: white is oklch(1 0 none), and a missing hue resolves to 0 in
-   calc(), so calc(c + 0.0181) calc(h + 6.6) turns a white background's shade
-   pink rather than leaving it neutral.
+   $l, $c and $h are named for the OKLCH channels they move, and are the only
+   arguments call sites pass. The rest are shared calibration.
 
-   $gate only has to separate "no chroma at all" from "a deliberate tint", so
-   it is steep. At 200 the delta is already at full strength by c = 0.005,
-   below any tint that reads as a color: #fef7ee sits at c = 0.0141 and keeps
-   the full warm shade it had before the gate existed. Lowering $gate does not
-   make tints subtler, it makes them weaker than designed.
+   CHROMA. Adding chroma unconditionally tints greys: white is oklch(1 0 none),
+   and a missing hue resolves to 0 in calc(), so calc(c + 0.0181) calc(h + 6.6)
+   turns a white background's shade pink rather than leaving it neutral. Ramping
+   $c by the origin's own chroma keeps greys grey. The ramp only has to separate
+   "no chroma at all" from "a deliberate tint", so $tint-above sits low: #fef7ee
+   is at c = 0.0141 and keeps the full warm shade it had before the ramp existed.
+   Raising $tint-above does not make tints subtler, it makes them weaker than
+   designed.
 
-   The lightness delta is multiplied by (1 - 2 * dark), which is 1 for a light
-   origin and -1 for a dark one, so $l always moves the shade away from the
-   origin. Subtracting unconditionally clamps at 0 on a near-black background
-   and the shade disappears. $pivot matches the threshold the --fg-color
-   contrast switches use, so the shade flips direction on the same colors that
-   flip the text.
+   LIGHTNESS. $l is multiplied by (1 - 2 * dark), which is 1 for a light origin
+   and -1 for a dark one, so the step always moves away from the origin.
+   Subtracting unconditionally clamps at 0 on a near-black background and the
+   shade disappears. $lighten-below matches the threshold the --fg-color contrast
+   switches use, so the shade flips direction on the same colors that flip the
+   text.
+
+   Flipping alone is not enough near black. OKLCH lightness is perceptually even,
+   but sRGB is not: L = 0.0225 off white gives #f7f7f7, while the same step off
+   black still quantizes to #000000. $lift adds ground clearance, ramped by how
+   close the origin is to black, so a black background shades to #121212 instead
+   of nothing. It tapers out by $lift-below, which keeps it away from mid-tones
+   and stops it compounding when one shade is derived from another. Light origins
+   never see it.
 
    Custom properties need interpolation, plain properties do not:
      --bg-shade-color: #{shade(var(--bg-color))};
      background-color: shade(var(--timer-bg), -0.058, 0.03, 0); */
-@function shade($from, $l: -0.0225, $c: 0.0181, $h: 6.6, $gate: 200, $pivot: 0.5) {
-  @return string.unquote("oklch(from #{$from} #{_lightness($l, $pivot)} #{_chroma($c, $gate)} #{_delta('h', $h)})");
+@function shade($from, $l: -0.0225, $c: 0.0181, $h: 6.6, $tint-above: 0.005, $lighten-below: 0.5, $lift: 0.16, $lift-below: 0.25) {
+  @return string.unquote("oklch(from #{$from} #{_lightness($l, $lighten-below, $lift, $lift-below)} #{_chroma($c, $tint-above)} #{_delta('h', $h)})");
 }

--- a/themes/kinder/styles/_color.scss
+++ b/themes/kinder/styles/_color.scss
@@ -1,0 +1,77 @@
+@use "sass:string";
+
+/* Emits a channel term, omitting the calc() when the delta is a no-op. */
+@function _delta($channel, $delta) {
+  @if $delta == 0 {
+    @return $channel;
+  }
+
+  @if $delta < 0 {
+    @return "calc(#{$channel} - #{-1 * $delta})";
+  }
+
+  @return "calc(#{$channel} + #{$delta})";
+}
+
+/* Emits the lightness term, flipping its direction on a dark origin. */
+@function _lightness($delta, $pivot) {
+  @if $delta == 0 {
+    @return "l";
+  }
+
+  $flip: "(1 - 2 * clamp(0, (#{$pivot} - l) * 9999, 1))";
+
+  @if $delta < 0 {
+    @return "calc(l - #{-1 * $delta} * #{$flip})";
+  }
+
+  @return "calc(l + #{$delta} * #{$flip})";
+}
+
+/* Emits the chroma term, scaled by how chromatic the origin already is. */
+@function _chroma($delta, $gate) {
+  @if $delta == 0 {
+    @return "c";
+  }
+
+  @if $delta < 0 {
+    @return "calc(c - #{-1 * $delta} * clamp(0, c * #{$gate}, 1))";
+  }
+
+  @return "calc(c + #{$delta} * clamp(0, c * #{$gate}, 1))";
+}
+
+/* Derives a shade from an origin color in OKLCH.
+
+   $from   origin color, e.g. var(--bg-color)
+   $l      lightness delta, expressed for a light origin and mirrored on a dark one
+   $c      chroma delta, reached in full once the origin's own chroma is 1 / $gate
+   $h      hue rotation, in degrees
+   $gate   inverse of the chroma at which $c applies in full
+   $pivot  lightness below which the origin counts as dark
+
+   The chroma delta is scaled by clamp(0, c * $gate, 1), which is 0 for an
+   achromatic origin and 1 once it is chromatic. Adding chroma unconditionally
+   tints greys: white is oklch(1 0 none), and a missing hue resolves to 0 in
+   calc(), so calc(c + 0.0181) calc(h + 6.6) turns a white background's shade
+   pink rather than leaving it neutral.
+
+   $gate only has to separate "no chroma at all" from "a deliberate tint", so
+   it is steep. At 200 the delta is already at full strength by c = 0.005,
+   below any tint that reads as a color: #fef7ee sits at c = 0.0141 and keeps
+   the full warm shade it had before the gate existed. Lowering $gate does not
+   make tints subtler, it makes them weaker than designed.
+
+   The lightness delta is multiplied by (1 - 2 * dark), which is 1 for a light
+   origin and -1 for a dark one, so $l always moves the shade away from the
+   origin. Subtracting unconditionally clamps at 0 on a near-black background
+   and the shade disappears. $pivot matches the threshold the --fg-color
+   contrast switches use, so the shade flips direction on the same colors that
+   flip the text.
+
+   Custom properties need interpolation, plain properties do not:
+     --bg-shade-color: #{shade(var(--bg-color))};
+     background-color: shade(var(--timer-bg), -0.058, 0.03, 0); */
+@function shade($from, $l: -0.0225, $c: 0.0181, $h: 6.6, $gate: 200, $pivot: 0.5) {
+  @return string.unquote("oklch(from #{$from} #{_lightness($l, $pivot)} #{_chroma($c, $gate)} #{_delta('h', $h)})");
+}

--- a/themes/kinder/styles/block.collection.scss
+++ b/themes/kinder/styles/block.collection.scss
@@ -1,6 +1,8 @@
+@use "color";
+
 @layer snippets {
   [ui-block="collection"] {
-    --bg-shade-color: oklch(from var(--bg-color) calc(l - 0.0225) calc(c + 0.0181) calc(h + 6.6));
+    --bg-shade-color: #{color.shade(var(--bg-color))};
 
     display: flex;
     gap: var(--spacing-16);

--- a/themes/kinder/styles/block.collection.scss
+++ b/themes/kinder/styles/block.collection.scss
@@ -1,8 +1,8 @@
-@use "color";
+@use "color" as *;
 
 @layer snippets {
   [ui-block="collection"] {
-    --bg-shade-color: #{color.shade(var(--bg-color))};
+    --bg-shade-color: #{shade(var(--bg-color))};
 
     display: flex;
     gap: var(--spacing-16);

--- a/themes/kinder/styles/block.product.scss
+++ b/themes/kinder/styles/block.product.scss
@@ -1,12 +1,14 @@
+@use "color";
+
 @layer reset, base, components, utilities, sections, snippets, overrides;
 
 @layer snippets {
   [ui-block="product"] {
     --bg-color: #fefefe;
-    --bg-shade-color: oklch(from var(--bg-color) calc(l - 0.018) c h);
+    --bg-shade-color: #{color.shade(var(--bg-color), -0.018, 0, 0)};
     --fg-color: oklch(from var(--bg-color) clamp(0, calc((0.5 - l) * 9999), 1) 0 none);
     --quantity-bg: var(--bg-shade-color);
-    --shadow-color: oklch(from var(--bg-color) calc(l - 0.0225) calc(c + 0.0181) calc(h + 6.6));
+    --shadow-color: #{color.shade(var(--bg-color))};
 
     display: flex;
     position: relative;

--- a/themes/kinder/styles/block.product.scss
+++ b/themes/kinder/styles/block.product.scss
@@ -1,14 +1,14 @@
-@use "color";
+@use "color" as *;
 
 @layer reset, base, components, utilities, sections, snippets, overrides;
 
 @layer snippets {
   [ui-block="product"] {
     --bg-color: #fefefe;
-    --bg-shade-color: #{color.shade(var(--bg-color), -0.018, 0, 0)};
+    --bg-shade-color: #{shade(var(--bg-color), -0.018, 0, 0)};
     --fg-color: oklch(from var(--bg-color) clamp(0, calc((0.5 - l) * 9999), 1) 0 none);
     --quantity-bg: var(--bg-shade-color);
-    --shadow-color: #{color.shade(var(--bg-color))};
+    --shadow-color: #{shade(var(--bg-color))};
 
     display: flex;
     position: relative;

--- a/themes/kinder/styles/components/core/button.scss
+++ b/themes/kinder/styles/components/core/button.scss
@@ -1,3 +1,5 @@
+@use "../../color";
+
 /*
   Component: Button
 
@@ -105,7 +107,7 @@
     border-radius: var(--radius-button);
 
     &:has([ui-slot="button-front"]) {
-      background-color: oklch(from var(--button-bg) calc(l - 0.08) c h);
+      background-color: color.shade(var(--button-bg), -0.08, 0, 0);
     }
 
     [ui-slot="button-front"] {
@@ -174,7 +176,7 @@
     }
 
     &:has([ui-slot="button-front"]) {
-      background-color: oklch(from var(--button-bg) calc(l - 0.08) c h);
+      background-color: color.shade(var(--button-bg), -0.08, 0, 0);
     }
   }
 

--- a/themes/kinder/styles/components/core/button.scss
+++ b/themes/kinder/styles/components/core/button.scss
@@ -1,4 +1,4 @@
-@use "../../color";
+@use "../../color" as *;
 
 /*
   Component: Button
@@ -107,7 +107,7 @@
     border-radius: var(--radius-button);
 
     &:has([ui-slot="button-front"]) {
-      background-color: color.shade(var(--button-bg), -0.08, 0, 0);
+      background-color: shade(var(--button-bg), -0.08, 0, 0);
     }
 
     [ui-slot="button-front"] {
@@ -176,7 +176,7 @@
     }
 
     &:has([ui-slot="button-front"]) {
-      background-color: color.shade(var(--button-bg), -0.08, 0, 0);
+      background-color: shade(var(--button-bg), -0.08, 0, 0);
     }
   }
 

--- a/themes/kinder/styles/components/core/divider.scss
+++ b/themes/kinder/styles/components/core/divider.scss
@@ -1,4 +1,4 @@
-@use "../../color";
+@use "../../color" as *;
 
 /* 
   Component: Divider
@@ -12,7 +12,7 @@
 */
 
 [ui-slot="divider"] {
-  --color-divider: #{color.shade(var(--bg-color), -0.05, 0, 0)};
+  --color-divider: #{shade(var(--bg-color), -0.05, 0, 0)};
 
   /* Variant */
   &[data-variant="line"] {

--- a/themes/kinder/styles/components/core/divider.scss
+++ b/themes/kinder/styles/components/core/divider.scss
@@ -1,3 +1,5 @@
+@use "../../color";
+
 /* 
   Component: Divider
 
@@ -10,7 +12,7 @@
 */
 
 [ui-slot="divider"] {
-  --color-divider: oklch(from var(--bg-color) calc(l - 0.05) c h);
+  --color-divider: #{color.shade(var(--bg-color), -0.05, 0, 0)};
 
   /* Variant */
   &[data-variant="line"] {

--- a/themes/kinder/styles/misc.search.scss
+++ b/themes/kinder/styles/misc.search.scss
@@ -1,4 +1,4 @@
-@use "color";
+@use "color" as *;
 
 @layer snippets {
   #search[popover] {
@@ -55,8 +55,8 @@
               border-radius: var(--radius-12);
 
               ui-image-fallback {
-                background-color: color.shade(var(--bg-color), -0.018, 0, 0);
-                color: color.shade(var(--fg-color), -0.4);
+                background-color: shade(var(--bg-color), -0.018, 0, 0);
+                color: shade(var(--fg-color), -0.4);
               }
 
               & > img {
@@ -90,7 +90,7 @@
                 .category {
                   padding: var(--spacing-4) var(--spacing-8);
                   border-radius: var(--radius-rounded);
-                  background-color: color.shade(var(--bg-color), -0.018, 0, 0);
+                  background-color: shade(var(--bg-color), -0.018, 0, 0);
                   font: var(--font-label-xs);
                   text-align: center;
                 }

--- a/themes/kinder/styles/misc.search.scss
+++ b/themes/kinder/styles/misc.search.scss
@@ -1,3 +1,5 @@
+@use "color";
+
 @layer snippets {
   #search[popover] {
     [ui-slot="sheet-body"] {
@@ -53,8 +55,8 @@
               border-radius: var(--radius-12);
 
               ui-image-fallback {
-                background-color: oklch(from var(--bg-color) calc(l - 0.018) c h);
-                color: oklch(from var(--fg-color) calc(l - 0.4) calc(c + 0.0181) calc(h + 6.6));
+                background-color: color.shade(var(--bg-color), -0.018, 0, 0);
+                color: color.shade(var(--fg-color), -0.4);
               }
 
               & > img {
@@ -88,7 +90,7 @@
                 .category {
                   padding: var(--spacing-4) var(--spacing-8);
                   border-radius: var(--radius-rounded);
-                  background-color: oklch(from var(--bg-color) calc(l - 0.018) c h);
+                  background-color: color.shade(var(--bg-color), -0.018, 0, 0);
                   font: var(--font-label-xs);
                   text-align: center;
                 }

--- a/themes/kinder/styles/misc.toast.scss
+++ b/themes/kinder/styles/misc.toast.scss
@@ -1,9 +1,9 @@
-@use "color";
+@use "color" as *;
 
 @layer snippets {
   ui-toast {
     --bg-color: #fefefe;
-    --bg-shade-color: #{color.shade(var(--bg-color), -0.018, 0, 0)};
+    --bg-shade-color: #{shade(var(--bg-color), -0.018, 0, 0)};
     --fg-color: oklch(from var(--bg-color) clamp(0, calc((0.5 - l) * 9999), 1) 0 none);
 
     inset: auto;

--- a/themes/kinder/styles/misc.toast.scss
+++ b/themes/kinder/styles/misc.toast.scss
@@ -1,7 +1,9 @@
+@use "color";
+
 @layer snippets {
   ui-toast {
     --bg-color: #fefefe;
-    --bg-shade-color: oklch(from var(--bg-color) calc(l - 0.018) c h);
+    --bg-shade-color: #{color.shade(var(--bg-color), -0.018, 0, 0)};
     --fg-color: oklch(from var(--bg-color) clamp(0, calc((0.5 - l) * 9999), 1) 0 none);
 
     inset: auto;

--- a/themes/kinder/styles/section.cart.scss
+++ b/themes/kinder/styles/section.cart.scss
@@ -1,8 +1,8 @@
-@use "color";
+@use "color" as *;
 
 @layer sections {
   [ui-section="cart"] {
-    --bg-shade-color: #{color.shade(var(--bg-color))};
+    --bg-shade-color: #{shade(var(--bg-color))};
 
     display: flex;
     gap: var(--spacing-48);
@@ -180,7 +180,7 @@
               gap: var(--spacing-8);
 
               [ui-slot="status-badge"] {
-                background-color: color.shade(var(--bg-shade-color), -0.0444, 0.0456, -1);
+                background-color: shade(var(--bg-shade-color), -0.0444, 0.0456, -1);
                 color: var(--fg-color);
                 font: var(--font-label-sm);
               }

--- a/themes/kinder/styles/section.cart.scss
+++ b/themes/kinder/styles/section.cart.scss
@@ -1,6 +1,8 @@
+@use "color";
+
 @layer sections {
   [ui-section="cart"] {
-    --bg-shade-color: oklch(from var(--bg-color) calc(l - 0.0225) calc(c + 0.0181) calc(h + 6.6));
+    --bg-shade-color: #{color.shade(var(--bg-color))};
 
     display: flex;
     gap: var(--spacing-48);
@@ -178,7 +180,7 @@
               gap: var(--spacing-8);
 
               [ui-slot="status-badge"] {
-                background-color: oklch(from var(--bg-shade-color) calc(l - 0.0444) calc(c + 0.0456) calc(h - 1));
+                background-color: color.shade(var(--bg-shade-color), -0.0444, 0.0456, -1);
                 color: var(--fg-color);
                 font: var(--font-label-sm);
               }

--- a/themes/kinder/styles/section.collection-tabs.scss
+++ b/themes/kinder/styles/section.collection-tabs.scss
@@ -1,4 +1,4 @@
-@use "color";
+@use "color" as *;
 
 @layer sections {
   [ui-section="collection-tabs"] {
@@ -19,7 +19,7 @@
         height: fit-content;
         padding: var(--spacing-24);
         border-radius: var(--radius-card);
-        background-color: color.shade(var(--bg-color));
+        background-color: shade(var(--bg-color));
         inset-block-start: var(--spacing-16);
         gap: var(--spacing-40);
 
@@ -158,7 +158,7 @@
 
 @layer snippets {
   [ui-block="product-tab"] {
-    --bg-shade-color: #{color.shade(var(--bg-color))};
+    --bg-shade-color: #{shade(var(--bg-color))};
 
     display: flex;
     gap: var(--spacing-16);

--- a/themes/kinder/styles/section.collection-tabs.scss
+++ b/themes/kinder/styles/section.collection-tabs.scss
@@ -1,3 +1,5 @@
+@use "color";
+
 @layer sections {
   [ui-section="collection-tabs"] {
     display: flex;
@@ -17,7 +19,7 @@
         height: fit-content;
         padding: var(--spacing-24);
         border-radius: var(--radius-card);
-        background-color: oklch(from var(--bg-color) calc(l - 0.0225) calc(c + 0.0181) calc(h + 6.6));
+        background-color: color.shade(var(--bg-color));
         inset-block-start: var(--spacing-16);
         gap: var(--spacing-40);
 
@@ -156,7 +158,7 @@
 
 @layer snippets {
   [ui-block="product-tab"] {
-    --bg-shade-color: oklch(from var(--bg-color) calc(l - 0.0225) calc(c + 0.0181) calc(h + 6.6));
+    --bg-shade-color: #{color.shade(var(--bg-color))};
 
     display: flex;
     gap: var(--spacing-16);

--- a/themes/kinder/styles/section.countdown-timer.scss
+++ b/themes/kinder/styles/section.countdown-timer.scss
@@ -1,3 +1,5 @@
+@use "color";
+
 @layer sections {
   [ui-section="countdown-timer"] {
     .timer-container {
@@ -56,7 +58,7 @@
               height: var(--segment-size);
               padding: var(--spacing-16);
               border-radius: var(--radius-16);
-              background-color: oklch(from var(--timer-bg) calc(l - 0.058) calc(c + 0.03) h);
+              background-color: color.shade(var(--timer-bg), -0.058, 0.03, 0);
               font: var(--font-heading-lg);
             }
           }

--- a/themes/kinder/styles/section.countdown-timer.scss
+++ b/themes/kinder/styles/section.countdown-timer.scss
@@ -1,4 +1,4 @@
-@use "color";
+@use "color" as *;
 
 @layer sections {
   [ui-section="countdown-timer"] {
@@ -58,7 +58,7 @@
               height: var(--segment-size);
               padding: var(--spacing-16);
               border-radius: var(--radius-16);
-              background-color: color.shade(var(--timer-bg), -0.058, 0.03, 0);
+              background-color: shade(var(--timer-bg), -0.058, 0.03, 0);
               font: var(--font-heading-lg);
             }
           }

--- a/themes/kinder/styles/section.faqs.scss
+++ b/themes/kinder/styles/section.faqs.scss
@@ -1,3 +1,5 @@
+@use "color";
+
 @layer sections {
   [ui-section="faqs"] {
     gap: var(--spacing-32);
@@ -20,7 +22,7 @@
           width: 400px;
           overflow: hidden;
           border-radius: calc(var(--radius-card) / 2);
-          background-color: oklch(from var(--inner-bg-color) calc(l - 0.0225) c h);
+          background-color: color.shade(var(--inner-bg-color), -0.0225, 0, 0);
 
           &[data-image-ratio="square"] {
             aspect-ratio: 1 / 1;

--- a/themes/kinder/styles/section.faqs.scss
+++ b/themes/kinder/styles/section.faqs.scss
@@ -1,4 +1,4 @@
-@use "color";
+@use "color" as *;
 
 @layer sections {
   [ui-section="faqs"] {
@@ -22,7 +22,7 @@
           width: 400px;
           overflow: hidden;
           border-radius: calc(var(--radius-card) / 2);
-          background-color: color.shade(var(--inner-bg-color), -0.0225, 0, 0);
+          background-color: shade(var(--inner-bg-color), -0.0225, 0, 0);
 
           &[data-image-ratio="square"] {
             aspect-ratio: 1 / 1;

--- a/themes/kinder/styles/section.featured-collection.scss
+++ b/themes/kinder/styles/section.featured-collection.scss
@@ -1,4 +1,4 @@
-@use "color";
+@use "color" as *;
 
 @layer sections {
   [ui-section="featured-collection"] {
@@ -12,7 +12,7 @@
       height: 640px;
       overflow: hidden;
       border-radius: var(--radius-card);
-      background-color: color.shade(var(--bg-color));
+      background-color: shade(var(--bg-color));
       inset-block-start: var(--spacing-16);
 
       &[data-banner-placement="first"] {

--- a/themes/kinder/styles/section.featured-collection.scss
+++ b/themes/kinder/styles/section.featured-collection.scss
@@ -1,3 +1,5 @@
+@use "color";
+
 @layer sections {
   [ui-section="featured-collection"] {
     display: flex;
@@ -10,7 +12,7 @@
       height: 640px;
       overflow: hidden;
       border-radius: var(--radius-card);
-      background-color: oklch(from var(--bg-color) calc(l - 0.0225) calc(c + 0.0181) calc(h + 6.6));
+      background-color: color.shade(var(--bg-color));
       inset-block-start: var(--spacing-16);
 
       &[data-banner-placement="first"] {

--- a/themes/kinder/styles/section.footer.scss
+++ b/themes/kinder/styles/section.footer.scss
@@ -1,3 +1,5 @@
+@use "color";
+
 @layer sections {
   [ui-layout="footer"] {
     --card-radius: var(--radius-card);
@@ -62,7 +64,7 @@
       gap: var(--spacing-48);
       padding: var(--card-spacing);
       border-radius: var(--card-radius);
-      background-color: oklch(from var(--bg-color) calc(l - 0.0225) calc(c + 0.0181) calc(h + 6.6));
+      background-color: color.shade(var(--bg-color));
 
       .groups {
         display: flex;

--- a/themes/kinder/styles/section.footer.scss
+++ b/themes/kinder/styles/section.footer.scss
@@ -1,4 +1,4 @@
-@use "color";
+@use "color" as *;
 
 @layer sections {
   [ui-layout="footer"] {
@@ -64,7 +64,7 @@
       gap: var(--spacing-48);
       padding: var(--card-spacing);
       border-radius: var(--card-radius);
-      background-color: color.shade(var(--bg-color));
+      background-color: shade(var(--bg-color));
 
       .groups {
         display: flex;

--- a/themes/kinder/styles/section.header.scss
+++ b/themes/kinder/styles/section.header.scss
@@ -1,4 +1,4 @@
-@use "color";
+@use "color" as *;
 
 @layer sections {
   [ui-layout="header"] {
@@ -198,7 +198,7 @@
         padding: var(--spacing-16);
         padding-block-end: var(--spacing-8);
         border-radius: var(--radius-8);
-        background-color: color.shade(var(--bg-color), -0.02, 0, 0);
+        background-color: shade(var(--bg-color), -0.02, 0, 0);
         gap: var(--spacing-8);
 
         .label {

--- a/themes/kinder/styles/section.header.scss
+++ b/themes/kinder/styles/section.header.scss
@@ -1,3 +1,5 @@
+@use "color";
+
 @layer sections {
   [ui-layout="header"] {
     display: grid;
@@ -196,7 +198,7 @@
         padding: var(--spacing-16);
         padding-block-end: var(--spacing-8);
         border-radius: var(--radius-8);
-        background-color: oklch(from var(--bg-color) calc(l - 0.02) c h);
+        background-color: color.shade(var(--bg-color), -0.02, 0, 0);
         gap: var(--spacing-8);
 
         .label {

--- a/themes/kinder/styles/section.image-banners.scss
+++ b/themes/kinder/styles/section.image-banners.scss
@@ -1,4 +1,4 @@
-@use "color";
+@use "color" as *;
 
 @layer sections {
   [ui-section="image-banners"] {
@@ -16,14 +16,14 @@
         padding: var(--spacing-32);
         overflow: hidden;
         border-radius: var(--radius-card);
-        background-color: color.shade(var(--bg-color));
+        background-color: shade(var(--bg-color));
 
         [ui-block="image"] {
           position: absolute;
           inset: 0;
 
           ui-image-fallback {
-            color: color.shade(var(--bg-color), -0.4);
+            color: shade(var(--bg-color), -0.4);
           }
 
           img {

--- a/themes/kinder/styles/section.image-banners.scss
+++ b/themes/kinder/styles/section.image-banners.scss
@@ -1,3 +1,5 @@
+@use "color";
+
 @layer sections {
   [ui-section="image-banners"] {
     .banners {
@@ -14,14 +16,14 @@
         padding: var(--spacing-32);
         overflow: hidden;
         border-radius: var(--radius-card);
-        background-color: oklch(from var(--bg-color) calc(l - 0.0225) calc(c + 0.0181) calc(h + 6.6));
+        background-color: color.shade(var(--bg-color));
 
         [ui-block="image"] {
           position: absolute;
           inset: 0;
 
           ui-image-fallback {
-            color: oklch(from var(--bg-color) calc(l - 0.4) calc(c + 0.0181) calc(h + 6.6));
+            color: color.shade(var(--bg-color), -0.4);
           }
 
           img {

--- a/themes/kinder/styles/section.image-with-text.scss
+++ b/themes/kinder/styles/section.image-with-text.scss
@@ -1,7 +1,9 @@
+@use "color";
+
 @layer sections {
   [ui-section="image-with-text"] {
     .wrapper-area {
-      --bg-shade-color: oklch(from var(--bg-color) calc(l - 0.0225) calc(c + 0.0181) calc(h + 6.6));
+      --bg-shade-color: #{color.shade(var(--bg-color))};
 
       display: grid;
       grid-template-columns: repeat(2, 1fr);
@@ -18,7 +20,7 @@
       [ui-block="media"] {
         height: inherit;
         overflow: hidden;
-        color: oklch(from var(--fg-color) calc(l - 0.4) calc(c + 0.0181) calc(h + 6.6));
+        color: color.shade(var(--fg-color), -0.4);
 
         & > img {
           object-fit: cover;

--- a/themes/kinder/styles/section.image-with-text.scss
+++ b/themes/kinder/styles/section.image-with-text.scss
@@ -1,9 +1,9 @@
-@use "color";
+@use "color" as *;
 
 @layer sections {
   [ui-section="image-with-text"] {
     .wrapper-area {
-      --bg-shade-color: #{color.shade(var(--bg-color))};
+      --bg-shade-color: #{shade(var(--bg-color))};
 
       display: grid;
       grid-template-columns: repeat(2, 1fr);
@@ -20,7 +20,7 @@
       [ui-block="media"] {
         height: inherit;
         overflow: hidden;
-        color: color.shade(var(--fg-color), -0.4);
+        color: shade(var(--fg-color), -0.4);
 
         & > img {
           object-fit: cover;

--- a/themes/kinder/styles/section.page.scss
+++ b/themes/kinder/styles/section.page.scss
@@ -1,6 +1,8 @@
+@use "color";
+
 @layer sections {
   [ui-section="page"] {
-    --bg-shade-color: oklch(from var(--bg-color) calc(l - 0.0225) calc(c + 0.0181) calc(h + 6.6));
+    --bg-shade-color: #{color.shade(var(--bg-color))};
 
     display: flex;
     flex-direction: column;

--- a/themes/kinder/styles/section.page.scss
+++ b/themes/kinder/styles/section.page.scss
@@ -1,8 +1,8 @@
-@use "color";
+@use "color" as *;
 
 @layer sections {
   [ui-section="page"] {
-    --bg-shade-color: #{color.shade(var(--bg-color))};
+    --bg-shade-color: #{shade(var(--bg-color))};
 
     display: flex;
     flex-direction: column;

--- a/themes/kinder/styles/section.product-information.scss
+++ b/themes/kinder/styles/section.product-information.scss
@@ -1,9 +1,9 @@
-@use "color";
+@use "color" as *;
 
 @layer sections {
   [ui-section="product-information"] {
-    --bg-shade-color: #{color.shade(var(--bg-color))};
-    --bg-on-shade-color: #{color.shade(var(--bg-shade-color), -0.02, 0.005, 1)} !important;
+    --bg-shade-color: #{shade(var(--bg-color))};
+    --bg-on-shade-color: #{shade(var(--bg-shade-color), -0.02, 0.005, 1)} !important;
 
     display: flex;
     gap: var(--spacing-24);

--- a/themes/kinder/styles/section.product-information.scss
+++ b/themes/kinder/styles/section.product-information.scss
@@ -1,7 +1,9 @@
+@use "color";
+
 @layer sections {
   [ui-section="product-information"] {
-    --bg-shade-color: oklch(from var(--bg-color) calc(l - 0.0225) calc(c + 0.0181) calc(h + 6.6));
-    --bg-on-shade-color: oklch(from var(--bg-shade-color) calc(l - 0.02) calc(c + 0.005) calc(h + 1)) !important;
+    --bg-shade-color: #{color.shade(var(--bg-color))};
+    --bg-on-shade-color: #{color.shade(var(--bg-shade-color), -0.02, 0.005, 1)} !important;
 
     display: flex;
     gap: var(--spacing-24);

--- a/themes/kinder/styles/section.reviews.scss
+++ b/themes/kinder/styles/section.reviews.scss
@@ -1,7 +1,9 @@
+@use "color";
+
 @layer sections {
   [ui-section="reviews"] {
     --star-color: #f7ca4d;
-    --bg-shade-color: oklch(from var(--bg-color) calc(l - 0.0225) calc(c + 0.0181) calc(h + 6.6));
+    --bg-shade-color: #{color.shade(var(--bg-color))};
 
     display: grid;
     grid-template-columns: 55% auto;

--- a/themes/kinder/styles/section.reviews.scss
+++ b/themes/kinder/styles/section.reviews.scss
@@ -1,9 +1,9 @@
-@use "color";
+@use "color" as *;
 
 @layer sections {
   [ui-section="reviews"] {
     --star-color: #f7ca4d;
-    --bg-shade-color: #{color.shade(var(--bg-color))};
+    --bg-shade-color: #{shade(var(--bg-color))};
 
     display: grid;
     grid-template-columns: 55% auto;

--- a/themes/kinder/styles/section.search.scss
+++ b/themes/kinder/styles/section.search.scss
@@ -1,8 +1,8 @@
-@use "color";
+@use "color" as *;
 
 @layer sections {
   [ui-section="search"] {
-    --bg-shade-color: #{color.shade(var(--bg-color))};
+    --bg-shade-color: #{shade(var(--bg-color))};
 
     display: flex;
     flex: 1;

--- a/themes/kinder/styles/section.search.scss
+++ b/themes/kinder/styles/section.search.scss
@@ -1,6 +1,8 @@
+@use "color";
+
 @layer sections {
   [ui-section="search"] {
-    --bg-shade-color: oklch(from var(--bg-color) calc(l - 0.0225) calc(c + 0.0181) calc(h + 6.6));
+    --bg-shade-color: #{color.shade(var(--bg-color))};
 
     display: flex;
     flex: 1;

--- a/themes/kinder/styles/section.single-collection.scss
+++ b/themes/kinder/styles/section.single-collection.scss
@@ -1,6 +1,8 @@
+@use "color";
+
 @layer sections {
   [ui-section="single-collection"] {
-    --bg-shade-color: oklch(from var(--bg-color) calc(l - 0.0225) calc(c + 0.0181) calc(h + 6.6));
+    --bg-shade-color: #{color.shade(var(--bg-color))};
 
     display: flex;
     gap: var(--spacing-48);

--- a/themes/kinder/styles/section.single-collection.scss
+++ b/themes/kinder/styles/section.single-collection.scss
@@ -1,8 +1,8 @@
-@use "color";
+@use "color" as *;
 
 @layer sections {
   [ui-section="single-collection"] {
-    --bg-shade-color: #{color.shade(var(--bg-color))};
+    --bg-shade-color: #{shade(var(--bg-color))};
 
     display: flex;
     gap: var(--spacing-48);

--- a/themes/kinder/styles/section.thankyou.scss
+++ b/themes/kinder/styles/section.thankyou.scss
@@ -1,6 +1,8 @@
+@use "color";
+
 @layer sections {
   [ui-section="thankyou"] {
-    --bg-shade-color: oklch(from var(--bg-color) calc(l - 0.0225) calc(c + 0.0181) calc(h + 6.6));
+    --bg-shade-color: #{color.shade(var(--bg-color))};
 
     display: grid;
     grid-template-columns: 1fr minmax(0, 460px);

--- a/themes/kinder/styles/section.thankyou.scss
+++ b/themes/kinder/styles/section.thankyou.scss
@@ -1,8 +1,8 @@
-@use "color";
+@use "color" as *;
 
 @layer sections {
   [ui-section="thankyou"] {
-    --bg-shade-color: #{color.shade(var(--bg-color))};
+    --bg-shade-color: #{shade(var(--bg-color))};
 
     display: grid;
     grid-template-columns: 1fr minmax(0, 460px);

--- a/themes/kinder/styles/section.upsell.scss
+++ b/themes/kinder/styles/section.upsell.scss
@@ -1,6 +1,8 @@
+@use "color";
+
 @layer sections {
   ui-upsell {
-    --bg-shade-color: oklch(from var(--bg-color) calc(l - 0.0225) calc(c + 0.0181) calc(h + 6.6));
+    --bg-shade-color: #{color.shade(var(--bg-color))};
 
     display: grid;
     grid-template-columns: 1fr 2fr;

--- a/themes/kinder/styles/section.upsell.scss
+++ b/themes/kinder/styles/section.upsell.scss
@@ -1,8 +1,8 @@
-@use "color";
+@use "color" as *;
 
 @layer sections {
   ui-upsell {
-    --bg-shade-color: #{color.shade(var(--bg-color))};
+    --bg-shade-color: #{shade(var(--bg-color))};
 
     display: grid;
     grid-template-columns: 1fr 2fr;


### PR DESCRIPTION
## Prerequisites

- [ ] Check this branch locally and run `pnpm run release`
- [ ] 3 new files will be generated in this format `theme name + date + .zip`
- [ ] Upload generated file locally or in seller-area test env

## QA Steps

- [ ] Go to theme editor
- [ ] Change any section's bg that has floating elements (cards) to a white
- [ ] the shade should be a light gray, instead of light red
- [ ] Now Change the section's bg to a very dark color
- [ ] The shade should lighten instead of darken (i.e a lighter color than the bg)

## Note

Leave empty when you have nothing to say.
